### PR TITLE
opt in and out to auto-init SDK

### DIFF
--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -24,10 +24,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug") {
-            isMinifyEnabled = false
-        }
+        getByName("debug")
         getByName("release") {
+//            isMinifyEnabled = true // Do we want to enable it for our lib?
             consumerProguardFiles("proguard-rules.pro")
         }
     }

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -26,7 +26,6 @@ android {
     buildTypes {
         getByName("debug")
         getByName("release") {
-//            isMinifyEnabled = true // Do we want to enable it for our lib?
             consumerProguardFiles("proguard-rules.pro")
         }
     }

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -8,11 +8,13 @@
 
 # Gson specific classes
 -dontwarn sun.misc.**
+-keep class com.google.gson.** { *; }
 #-keep class com.google.gson.stream.** { *; }
 
 # Application classes that will be serialized/deserialized over Gson
--keep class io.sentry.** { <fields>; }
--keep class io.sentry.protocol.** { <fields>; }
+-keep class io.sentry.core.** { <fields>; }
+-keep class io.sentry.core.protocol.** { <fields>; }
+-keepclassmembers enum * { *; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)

--- a/sentry-android-core/src/main/AndroidManifest.xml
+++ b/sentry-android-core/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <provider
       android:name=".SentryInitProvider"
       android:authorities="${applicationId}.SentryInitProvider"
-      android:exported="false"
-      android:initOrder="2147483647" />
+      android:exported="false" />
   </application>
 </manifest>

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -7,8 +7,11 @@ class AndroidOptionsInitializer {
   static void init(SentryOptions options, Context context) {
     // Firstly set the logger, if `debug=true` configured, logging can start asap.
     options.setLogger(new AndroidLogger());
-    ManifestMetadataReader.applyMetadata(context, options);
-    options.addEventProcessor(new DefaultAndroidEventProcessor(context));
-    options.setSerializer(new AndroidSerializer());
+
+    if (ManifestMetadataReader.isAutoInit(context, options)) {
+      ManifestMetadataReader.applyMetadata(context, options);
+      options.addEventProcessor(new DefaultAndroidEventProcessor(context));
+      options.setSerializer(new AndroidSerializer());
+    }
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -11,14 +11,11 @@ class ManifestMetadataReader {
 
   static final String DSN_KEY = "io.sentry.dsn";
   static final String DEBUG_KEY = "io.sentry.debug";
+  static final String AUTO_INIT = "io.sentry.auto-init";
 
   public static void applyMetadata(Context context, SentryOptions options) {
     try {
-      ApplicationInfo app =
-          context
-              .getPackageManager()
-              .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-      Bundle metadata = app.metaData;
+      Bundle metadata = getMetadata(context);
 
       if (metadata != null) {
         options.setDebug(metadata.getBoolean(DEBUG_KEY, options.isDebug()));
@@ -37,5 +34,29 @@ class ManifestMetadataReader {
           .log(
               SentryLevel.ERROR, "Failed to read configuration from android manifest metadata.", e);
     }
+  }
+
+  public static boolean isAutoInit(Context context, SentryOptions options) {
+    boolean autoInit = true;
+    try {
+      Bundle metadata = getMetadata(context);
+      if (metadata != null) {
+        autoInit = metadata.getBoolean(AUTO_INIT, true);
+        options.getLogger().log(SentryLevel.DEBUG, "Auto-init: %s", autoInit);
+      }
+    } catch (Exception e) {
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to read auto-init from android manifest metadata.", e);
+    }
+    return autoInit;
+  }
+
+  private static Bundle getMetadata(Context context) throws PackageManager.NameNotFoundException {
+    ApplicationInfo app =
+        context
+            .getPackageManager()
+            .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+    return app.metaData;
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
@@ -108,6 +108,24 @@ class SentryInitProviderTest {
         assertFailsWith<InvalidDsnException> { sentryInitProvider.attachInfo(mockContext, providerInfo) }
     }
 
+    @Test
+    fun `when applicationId is defined, auto-init in meta-data is set to false, SDK doesnt initialize`() {
+        val providerInfo = ProviderInfo()
+
+        assertFalse(Sentry.isEnabled())
+        providerInfo.authority = BuildConfig.LIBRARY_PACKAGE_NAME + AUTHORITY
+
+        val mockContext: Context = mock()
+        val metaData = Bundle()
+        mockMetaData(mockContext, metaData)
+
+        metaData.putBoolean(ManifestMetadataReader.AUTO_INIT, false)
+
+        sentryInitProvider.attachInfo(mockContext, providerInfo)
+
+        assertFalse(Sentry.isEnabled())
+    }
+
     private fun mockMetaData(mockContext: Context, metaData: Bundle) {
         val mockPackageManager: PackageManager = mock()
         val mockApplicationInfo: ApplicationInfo = mock()

--- a/sentry-sample/build.gradle.kts
+++ b/sentry-sample/build.gradle.kts
@@ -25,10 +25,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug") {
-            isMinifyEnabled = false
-        }
+        getByName("debug")
         getByName("release") {
+            isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
 
     <meta-data android:name="io.sentry.dsn" android:value="https://key@sentry.io/123" />
     <meta-data android:name="io.sentry.debug" android:value="true" />
+<!--    <meta-data android:name="io.sentry.auto-init" android:value="false" /> // how to disable the auto-init-->
   </application>
 
 </manifest>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Added the option via Manifest conf. to disable the auto-init of the Sentry SDK, so before fully initing the SDK we check this flag and don't do anything, the user may init. using a custom Application class.


## :bulb: Motivation and Context
the user may want to init. the SDK by code and pass custom parameters based on buildType/flavors and so on.


## :green_heart: How did you test it?
Mocking the manifest value and unit testing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
This should be written in the setup documentation