### PR TITLE
No need to generate BuildConfig for libs

### DIFF
--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -69,6 +69,16 @@ android {
     lintOptions {
         isWarningsAsErrors = true
         isCheckDependencies = true
+
+        // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+        isCheckReleaseBuilds = false
+    }
+
+    // replace with https://issuetracker.google.com/issues/72050365 once released.
+    libraryVariants.all {
+        generateBuildConfigProvider?.configure {
+            enabled = false
+        }
     }
 }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import io.sentry.core.Sentry;
 
 public class SentryInitProvider extends ContentProvider {
+
   @Override
   public boolean onCreate() {
     Sentry.init(o -> AndroidOptionsInitializer.init(o, getContext()));
@@ -23,8 +24,7 @@ public class SentryInitProvider extends ContentProvider {
   @Override
   public void attachInfo(Context context, ProviderInfo info) {
     // applicationId is expected to be prepended. See AndroidManifest.xml
-    if ("io.sentry.android.core.SentryInitProvider".equals(info.authority)) {
-      //
+    if (SentryInitProvider.class.getName().equals(info.authority)) {
       throw new IllegalStateException(
           "An applicationId is required to fulfill the manifest placeholder.");
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class SentryInitProviderTest {
-    private var sentryInitProvider: SentryInitProvider = SentryInitProvider()
+    private var sentryInitProvider = SentryInitProvider()
 
     private lateinit var context: Context
 
@@ -34,7 +34,7 @@ class SentryInitProviderTest {
     fun `when missing applicationId, SentryInitProvider throws`() {
         val providerInfo = ProviderInfo()
 
-        providerInfo.authority = AUTHORITY
+        providerInfo.authority = SentryInitProvider::class.java.name
         assertFailsWith<IllegalStateException> { sentryInitProvider.attachInfo(context, providerInfo) }
     }
 
@@ -43,7 +43,7 @@ class SentryInitProviderTest {
         val providerInfo = ProviderInfo()
 
         assertFalse(Sentry.isEnabled())
-        providerInfo.authority = BuildConfig.LIBRARY_PACKAGE_NAME + AUTHORITY
+        providerInfo.authority = AUTHORITY
 
         val mockContext: Context = mock()
         val metaData = Bundle()
@@ -61,7 +61,7 @@ class SentryInitProviderTest {
         val providerInfo = ProviderInfo()
 
         assertFalse(Sentry.isEnabled())
-        providerInfo.authority = BuildConfig.LIBRARY_PACKAGE_NAME + AUTHORITY
+        providerInfo.authority = AUTHORITY
 
         val mockContext: Context = mock()
         val metaData = Bundle()
@@ -79,7 +79,7 @@ class SentryInitProviderTest {
         val providerInfo = ProviderInfo()
 
         assertFalse(Sentry.isEnabled())
-        providerInfo.authority = BuildConfig.LIBRARY_PACKAGE_NAME + AUTHORITY
+        providerInfo.authority = AUTHORITY
 
         val mockContext: Context = mock()
         val metaData = Bundle()
@@ -97,7 +97,7 @@ class SentryInitProviderTest {
         val providerInfo = ProviderInfo()
 
         assertFalse(Sentry.isEnabled())
-        providerInfo.authority = BuildConfig.LIBRARY_PACKAGE_NAME + AUTHORITY
+        providerInfo.authority = AUTHORITY
 
         val mockContext: Context = mock()
         val metaData = Bundle()
@@ -112,7 +112,7 @@ class SentryInitProviderTest {
         val mockPackageManager: PackageManager = mock()
         val mockApplicationInfo: ApplicationInfo = mock()
 
-        whenever(mockContext.packageName).thenReturn(TEST_PACKAGE)
+        whenever(mockContext.packageName).thenReturn("io.sentry.sample.test")
         whenever(mockContext.packageManager).thenReturn(mockPackageManager)
         whenever(mockPackageManager.getApplicationInfo(mockContext.packageName, PackageManager.GET_META_DATA)).thenReturn(mockApplicationInfo)
 
@@ -120,7 +120,6 @@ class SentryInitProviderTest {
     }
 
     companion object {
-        private const val AUTHORITY = "io.sentry.android.core.SentryInitProvider"
-        private const val TEST_PACKAGE = "io.sentry.android.core.test"
+        private const val AUTHORITY = "io.sentry.sample.SentryInitProvider"
     }
 }

--- a/sentry-android/build.gradle.kts
+++ b/sentry-android/build.gradle.kts
@@ -7,6 +7,7 @@ android {
     buildToolsVersion(Config.Android.buildToolsVersion)
 
     defaultConfig {
+        targetSdkVersion(Config.Android.targetSdkVersion)
         minSdkVersion(Config.Android.minSdkVersion)
 
         missingDimensionStrategy(Config.Flavors.dimension, Config.Flavors.production)
@@ -15,6 +16,13 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    // replace with https://issuetracker.google.com/issues/72050365 once released.
+    libraryVariants.all {
+        generateBuildConfigProvider?.configure {
+            enabled = false
+        }
     }
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
libs don't need to generate BuildConfig and lints check don't need to run over Release type as well every time.


## :bulb: Motivation and Context
Speed up the build.
It doesn't generate the useless BuildConfig for libs.


## :green_heart: How did you test it?
Debugging and changing the unit tests to not use BuildConfig.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
