### PR TITLE
fixed broken test using BuildConfig

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
@@ -113,7 +113,7 @@ class SentryInitProviderTest {
         val providerInfo = ProviderInfo()
 
         assertFalse(Sentry.isEnabled())
-        providerInfo.authority = BuildConfig.LIBRARY_PACKAGE_NAME + AUTHORITY
+        providerInfo.authority = AUTHORITY
 
         val mockContext: Context = mock()
         val metaData = Bundle()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
it fixes a broken test.


## :bulb: Motivation and Context
the test was making use of BuildConfig which was removed by another PR.
caused by the combination of 2 PRs
https://github.com/getsentry/sentry-android/pull/30
https://github.com/getsentry/sentry-android/pull/31


## :green_heart: How did you test it?
being sure that all the tests and build were green

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
