### PR TITLE
Reading auto-init even before calling Sentry.init(...)

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -7,11 +7,8 @@ class AndroidOptionsInitializer {
   static void init(SentryOptions options, Context context) {
     // Firstly set the logger, if `debug=true` configured, logging can start asap.
     options.setLogger(new AndroidLogger());
-
-    if (ManifestMetadataReader.isAutoInit(context, options)) {
-      ManifestMetadataReader.applyMetadata(context, options);
-      options.addEventProcessor(new DefaultAndroidEventProcessor(context));
-      options.setSerializer(new AndroidSerializer());
-    }
+    ManifestMetadataReader.applyMetadata(context, options);
+    options.addEventProcessor(new DefaultAndroidEventProcessor(context));
+    options.setSerializer(new AndroidSerializer());
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import io.sentry.core.ILogger;
 import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
 
@@ -14,6 +15,8 @@ class ManifestMetadataReader {
   static final String AUTO_INIT = "io.sentry.auto-init";
 
   public static void applyMetadata(Context context, SentryOptions options) {
+    if (context == null) throw new IllegalArgumentException("The application context is required.");
+
     try {
       Bundle metadata = getMetadata(context);
 
@@ -21,13 +24,13 @@ class ManifestMetadataReader {
         options.setDebug(metadata.getBoolean(DEBUG_KEY, options.isDebug()));
         String dsn = metadata.getString(DSN_KEY, null);
         if (dsn != null) {
-          options.getLogger().log(SentryLevel.DEBUG, "DSN read: %s", dsn);
+          options.getLogger().log(SentryLevel.INFO, "DSN read: %s", dsn);
           options.setDsn(dsn);
         }
       }
       options
           .getLogger()
-          .log(SentryLevel.INFO, "Retrieving configuration from AndroidManifest.xml");
+          .log(SentryLevel.DEBUG, "Retrieving configuration from AndroidManifest.xml");
     } catch (Exception e) {
       options
           .getLogger()
@@ -36,18 +39,18 @@ class ManifestMetadataReader {
     }
   }
 
-  public static boolean isAutoInit(Context context, SentryOptions options) {
+  public static boolean isAutoInit(Context context, ILogger logger) {
+    if (context == null) throw new IllegalArgumentException("The application context is required.");
+
     boolean autoInit = true;
     try {
       Bundle metadata = getMetadata(context);
       if (metadata != null) {
         autoInit = metadata.getBoolean(AUTO_INIT, true);
-        options.getLogger().log(SentryLevel.DEBUG, "Auto-init: %s", autoInit);
+        logger.log(SentryLevel.DEBUG, "Auto-init: %s", autoInit);
       }
     } catch (Exception e) {
-      options
-          .getLogger()
-          .log(SentryLevel.ERROR, "Failed to read auto-init from android manifest metadata.", e);
+      logger.log(SentryLevel.ERROR, "Failed to read auto-init from android manifest metadata.", e);
     }
     return autoInit;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -1,5 +1,7 @@
 package io.sentry.android.core;
 
+import static io.sentry.core.ILogger.log;
+
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -22,23 +24,25 @@ class ManifestMetadataReader {
 
       if (metadata != null) {
         boolean debug = metadata.getBoolean(DEBUG_KEY, options.isDebug());
-        options.getLogger().log(SentryLevel.DEBUG, "debug read: %s", debug);
+        log(options.getLogger(), SentryLevel.DEBUG, "debug read: %s", debug);
         options.setDebug(debug);
 
         String dsn = metadata.getString(DSN_KEY, null);
         if (dsn != null) {
-          options.getLogger().log(SentryLevel.DEBUG, "DSN read: %s", dsn);
+          log(options.getLogger(), SentryLevel.DEBUG, "DSN read: %s", dsn);
           options.setDsn(dsn);
         }
       }
-      options
-          .getLogger()
-          .log(SentryLevel.INFO, "Retrieving configuration from AndroidManifest.xml");
+      log(
+          options.getLogger(),
+          SentryLevel.INFO,
+          "Retrieving configuration from AndroidManifest.xml");
     } catch (Exception e) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.ERROR, "Failed to read configuration from android manifest metadata.", e);
+      log(
+          options.getLogger(),
+          SentryLevel.ERROR,
+          "Failed to read configuration from android manifest metadata.",
+          e);
     }
   }
 
@@ -50,11 +54,11 @@ class ManifestMetadataReader {
       Bundle metadata = getMetadata(context);
       if (metadata != null) {
         autoInit = metadata.getBoolean(AUTO_INIT, true);
-        logger.log(SentryLevel.DEBUG, "Auto-init: %s", autoInit);
+        log(logger, SentryLevel.DEBUG, "Auto-init: %s", autoInit);
       }
-      logger.log(SentryLevel.INFO, "Retrieving auto-init from AndroidManifest.xml");
+      log(logger, SentryLevel.INFO, "Retrieving auto-init from AndroidManifest.xml");
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Failed to read auto-init from android manifest metadata.", e);
+      log(logger, SentryLevel.ERROR, "Failed to read auto-init from android manifest metadata.", e);
     }
     return autoInit;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
@@ -12,7 +12,10 @@ public class SentryInitProvider extends ContentProvider {
 
   @Override
   public boolean onCreate() {
-    Sentry.init(o -> AndroidOptionsInitializer.init(o, getContext()));
+    AndroidLogger logger = new AndroidLogger();
+    if (ManifestMetadataReader.isAutoInit(getContext(), logger)) {
+      Sentry.init(o -> AndroidOptionsInitializer.init(o, getContext()));
+    }
     return true;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -20,7 +20,7 @@ public class SentryClient implements ISentryClient {
   public SentryId captureEvent(SentryEvent event) {
     ILogger logger = options.getLogger();
     if (logger != null) {
-      logger.log(SentryLevel.DEBUG, "Capturing event: %s", event.getEventId());
+      logger.log(SentryLevel.INFO, "Capturing event: %s", event.getEventId());
     }
     return event.getEventId();
   }
@@ -42,7 +42,7 @@ public class SentryClient implements ISentryClient {
   public void close() {
     ILogger logger = options.getLogger();
     if (logger != null) {
-      logger.log(SentryLevel.INFO, "Closing SDK.");
+      logger.log(SentryLevel.DEBUG, "Closing SDK.");
     }
     // TODO: Flush events
     isEnabled = false;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Sentry.init(...) will be called only if auto-init is enabled


## :bulb: Motivation and Context
We check if auto-init is enabled inside of the Sentry.init(...) method, this should be done even before calling it.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
