### PR TITLE
added the unknown field to all the objects

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidSerializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidSerializer.java
@@ -33,7 +33,7 @@ public class AndroidSerializer implements ISerializer {
         .registerTypeAdapter(Date.class, new DateSerializerAdapter(logger))
         .registerTypeAdapter(Date.class, new DateDeserializerAdapter(logger))
         .registerTypeAdapter(TimeZone.class, new TimeZoneSerializerAdapter(logger))
-        .registerTypeAdapter(TimeZone.class, new TImeZoneDeserializerAdapter(logger))
+        .registerTypeAdapter(TimeZone.class, new TimeZoneDeserializerAdapter(logger))
         .registerTypeAdapter(
             Device.DeviceOrientation.class, new OrientationSerializerAdapter(logger))
         .registerTypeAdapter(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/adapters/TimeZoneDeserializerAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/adapters/TimeZoneDeserializerAdapter.java
@@ -11,11 +11,11 @@ import io.sentry.core.SentryLevel;
 import java.lang.reflect.Type;
 import java.util.TimeZone;
 
-public class TImeZoneDeserializerAdapter implements JsonDeserializer<TimeZone> {
+public class TimeZoneDeserializerAdapter implements JsonDeserializer<TimeZone> {
 
   private final ILogger logger;
 
-  public TImeZoneDeserializerAdapter(ILogger logger) {
+  public TimeZoneDeserializerAdapter(ILogger logger) {
     this.logger = logger;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
+++ b/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
@@ -3,13 +3,14 @@ package io.sentry.core;
 import java.util.Date;
 import java.util.Map;
 
-public class Breadcrumb {
+public class Breadcrumb implements IUnknownPropertiesConsumer {
   private Date timestamp;
   private String message;
   private String type;
   private Map<String, String> data;
   private String category;
   private SentryLevel level;
+  private Map<String, Object> unknown;
 
   public Date getTimestamp() {
     return timestamp;
@@ -57,5 +58,10 @@ public class Breadcrumb {
 
   public void setLevel(SentryLevel level) {
     this.level = level;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
@@ -1,6 +1,7 @@
 package io.sentry.core;
 
 import io.sentry.core.protocol.*;
+import io.sentry.core.util.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -239,6 +240,7 @@ public class SentryEvent implements IUnknownPropertiesConsumer {
     this.unknown = unknown;
   }
 
+  @VisibleForTesting
   public Map<String, Object> getUnknown() {
     return unknown;
   }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/App.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/App.java
@@ -1,8 +1,10 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.Date;
+import java.util.Map;
 
-public class App {
+public class App implements IUnknownPropertiesConsumer {
   static final String TYPE = "app";
 
   private String identifier;
@@ -12,6 +14,7 @@ public class App {
   private String name;
   private String version;
   private String build;
+  private Map<String, Object> unknown;
 
   public String getIdentifier() {
     return identifier;
@@ -67,5 +70,10 @@ public class App {
 
   public void setBuild(String build) {
     this.build = build;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Browser.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Browser.java
@@ -1,9 +1,13 @@
 package io.sentry.core.protocol;
 
-public class Browser {
+import io.sentry.core.IUnknownPropertiesConsumer;
+import java.util.Map;
+
+public class Browser implements IUnknownPropertiesConsumer {
   static final String TYPE = "browser";
   private String name;
   private String version;
+  private Map<String, Object> unknown;
 
   public String getName() {
     return name;
@@ -19,5 +23,10 @@ public class Browser {
 
   public void setVersion(String version) {
     this.version = version;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Device.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Device.java
@@ -1,9 +1,11 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.Date;
+import java.util.Map;
 import java.util.TimeZone;
 
-public class Device {
+public class Device implements IUnknownPropertiesConsumer {
   static final String TYPE = "device";
 
   private String name;
@@ -31,6 +33,7 @@ public class Device {
   private Integer screenDpi;
   private Date bootTime;
   private TimeZone timezone;
+  private Map<String, Object> unknown;
 
   public String getName() {
     return name;
@@ -230,6 +233,11 @@ public class Device {
 
   public void setTimezone(TimeZone timezone) {
     this.timezone = timezone;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 
   public enum DeviceOrientation {

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Gpu.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Gpu.java
@@ -1,6 +1,9 @@
 package io.sentry.core.protocol;
 
-public class Gpu {
+import io.sentry.core.IUnknownPropertiesConsumer;
+import java.util.Map;
+
+public class Gpu implements IUnknownPropertiesConsumer {
   static final String TYPE = "gpu";
 
   private String name;
@@ -12,6 +15,7 @@ public class Gpu {
   private Boolean multiThreadedRendering;
   private String version;
   private String npotSupport;
+  private Map<String, Object> unknown;
 
   public String getName() {
     return name;
@@ -83,5 +87,10 @@ public class Gpu {
 
   public void setNpotSupport(String npotSupport) {
     this.npotSupport = npotSupport;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Mechanism.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Mechanism.java
@@ -1,14 +1,16 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.Map;
 
-public class Mechanism {
+public class Mechanism implements IUnknownPropertiesConsumer {
   private String type;
   private String description;
   private String helpLink;
   private Boolean handled;
   private Map<String, Object> meta;
   private Map<String, Object> data;
+  private Map<String, Object> unknown;
 
   public String getType() {
     return type;
@@ -56,5 +58,10 @@ public class Mechanism {
 
   public void setData(Map<String, Object> data) {
     this.data = data;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Message.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Message.java
@@ -1,13 +1,16 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.List;
+import java.util.Map;
 
 // https://docs.sentry.io/development/sdk-dev/event-payloads/message/
 
-public class Message {
+public class Message implements IUnknownPropertiesConsumer {
   private String formatted;
   private String message;
   private List<String> params;
+  private Map<String, Object> unknown;
 
   public String getFormatted() {
     return formatted;
@@ -32,5 +35,10 @@ public class Message {
 
   public void setParams(List<String> params) {
     this.params = params;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/OperatingSystem.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/OperatingSystem.java
@@ -1,6 +1,9 @@
 package io.sentry.core.protocol;
 
-public class OperatingSystem {
+import io.sentry.core.IUnknownPropertiesConsumer;
+import java.util.Map;
+
+public class OperatingSystem implements IUnknownPropertiesConsumer {
   static final String TYPE = "os";
 
   private String name;
@@ -9,6 +12,7 @@ public class OperatingSystem {
   private String build;
   private String kernelVersion;
   private Boolean rooted;
+  private Map<String, Object> unknown;
 
   public String getName() {
     return name;
@@ -56,5 +60,10 @@ public class OperatingSystem {
 
   public void setRooted(Boolean rooted) {
     this.rooted = rooted;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Package.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Package.java
@@ -1,8 +1,12 @@
 package io.sentry.core.protocol;
 
-public class Package {
+import io.sentry.core.IUnknownPropertiesConsumer;
+import java.util.Map;
+
+public class Package implements IUnknownPropertiesConsumer {
   private String name;
   private String version;
+  private Map<String, Object> unknown;
 
   public String getName() {
     return name;
@@ -18,5 +22,10 @@ public class Package {
 
   public void setVersion(String version) {
     this.version = version;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Request.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Request.java
@@ -1,8 +1,9 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.Map;
 
-public class Request {
+public class Request implements IUnknownPropertiesConsumer {
   private String url;
   private String method;
   private String queryString;
@@ -11,6 +12,7 @@ public class Request {
   private Map<String, String> headers;
   private Map<String, String> env;
   private Map<String, String> other;
+  private Map<String, Object> unknown;
 
   public String getUrl() {
     return url;
@@ -74,5 +76,10 @@ public class Request {
 
   public void setOther(Map<String, String> other) {
     this.other = other;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Runtime.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Runtime.java
@@ -1,12 +1,16 @@
 package io.sentry.core.protocol;
 
-public class Runtime {
+import io.sentry.core.IUnknownPropertiesConsumer;
+import java.util.Map;
+
+public class Runtime implements IUnknownPropertiesConsumer {
   static final String TYPE = "runtime";
 
   private String name;
   private String version;
   private String rawDescription;
   private String build;
+  private Map<String, Object> unknown;
 
   public String getName() {
     return name;
@@ -38,5 +42,10 @@ public class Runtime {
 
   public void setBuild(String build) {
     this.build = build;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/SdkVersion.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SdkVersion.java
@@ -1,12 +1,15 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-public class SdkVersion {
+public class SdkVersion implements IUnknownPropertiesConsumer {
   private String name;
   private String version;
   private List<Package> packages = new CopyOnWriteArrayList<>();
+  private Map<String, Object> unknown;
 
   public String getVersion() {
     return version;
@@ -36,5 +39,10 @@ public class SdkVersion {
     newPackage.setName(name);
     newPackage.setVersion(version);
     packages.add(newPackage);
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/SentryException.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SentryException.java
@@ -1,13 +1,17 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
+import java.util.Map;
+
 /** The Sentry Exception interface. */
-public class SentryException {
+public class SentryException implements IUnknownPropertiesConsumer {
   private String type;
   private String value;
   private String module;
   private Integer threadId;
   private SentryStackTrace stacktrace;
   private Mechanism mechanism;
+  private Map<String, Object> unknown;
 
   /**
    * The Exception Type.
@@ -111,5 +115,10 @@ public class SentryException {
    */
   public void setMechanism(Mechanism mechanism) {
     this.mechanism = mechanism;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackFrame.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackFrame.java
@@ -1,10 +1,11 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.List;
 import java.util.Map;
 
 /** The Sentry stack frame. */
-public class SentryStackFrame {
+public class SentryStackFrame implements IUnknownPropertiesConsumer {
   private List<String> preContext;
   private List<String> postContext;
   private Map<String, String> vars;
@@ -22,6 +23,7 @@ public class SentryStackFrame {
   private Long imageAddress;
   private Long SymbolAddress;
   private Long instructionOffset;
+  private Map<String, Object> unknown;
 
   public List<String> getPreContext() {
     return preContext;
@@ -157,5 +159,10 @@ public class SentryStackFrame {
 
   public void setInstructionOffset(Long instructionOffset) {
     this.instructionOffset = instructionOffset;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackTrace.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackTrace.java
@@ -1,10 +1,13 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.List;
+import java.util.Map;
 
 /** The Sentry stacktrace. */
-public class SentryStackTrace {
+public class SentryStackTrace implements IUnknownPropertiesConsumer {
   private List<SentryStackFrame> frames;
+  private Map<String, Object> unknown;
 
   /**
    * Gets the frames of this stacktrace.
@@ -22,5 +25,10 @@ public class SentryStackTrace {
    */
   public void setFrames(List<SentryStackFrame> frames) {
     this.frames = frames;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/SentryThread.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SentryThread.java
@@ -1,12 +1,16 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
+import java.util.Map;
+
 /** Describes a thread in the Sentry protocol. */
-public class SentryThread {
+public class SentryThread implements IUnknownPropertiesConsumer {
   private Integer id;
   private String name;
   private Boolean crashed;
   private Boolean current;
   private SentryStackTrace stacktrace;
+  private Map<String, Object> unknown;
 
   /**
    * Gets the Id of the thread.
@@ -96,5 +100,10 @@ public class SentryThread {
    */
   public void setStacktrace(SentryStackTrace stacktrace) {
     this.stacktrace = stacktrace;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/User.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/User.java
@@ -1,14 +1,16 @@
 package io.sentry.core.protocol;
 
+import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.Map;
 
 /** The user affected by an event. */
-public class User {
+public class User implements IUnknownPropertiesConsumer {
   private String email;
   private String id;
   private String username;
   private String ipAddress;
   private Map<String, String> other;
+  private Map<String, Object> unknown;
 
   /**
    * Gets the e-mail address of the user.
@@ -98,5 +100,10 @@ public class User {
    */
   public void setOther(Map<String, String> other) {
     this.other = other;
+  }
+
+  @Override
+  public void acceptUnknownProperties(Map<String, Object> unknown) {
+    this.unknown = unknown;
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
added the unknown field to all the objects of the protocol


## :bulb: Motivation and Context
if the protocol is extended and all the SDKs are not synced, this will still send the properties over.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
in the future get rid of IUnknownPropertiesConsumer if we decide to do our own json parser or stick to Gson