### PR TITLE
ref: Reuse logger instance if possible

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -1,12 +1,17 @@
 package io.sentry.android.core;
 
 import android.content.Context;
+import io.sentry.core.ILogger;
 import io.sentry.core.SentryOptions;
 
 class AndroidOptionsInitializer {
   static void init(SentryOptions options, Context context) {
+    init(options, context, new AndroidLogger());
+  }
+
+  static void init(SentryOptions options, Context context, ILogger logger) {
     // Firstly set the logger, if `debug=true` configured, logging can start asap.
-    options.setLogger(new AndroidLogger());
+    options.setLogger(logger);
 
     // TODO this needs to fetch the data from somewhere - defined at build time?
     options.setSentryClientName("sentry-android/0.0.1");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
@@ -14,7 +14,7 @@ public class SentryInitProvider extends ContentProvider {
   public boolean onCreate() {
     AndroidLogger logger = new AndroidLogger();
     if (ManifestMetadataReader.isAutoInit(getContext(), logger)) {
-      Sentry.init(o -> AndroidOptionsInitializer.init(o, getContext()));
+      Sentry.init(o -> AndroidOptionsInitializer.init(o, getContext(), logger));
     }
     return true;
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import io.sentry.core.ILogger
 import io.sentry.core.SentryOptions
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -43,8 +44,9 @@ class AndroidOptionsInitializerTest {
         val mockContext = mock<Context> {
             on { applicationContext } doReturn context
         }
+        val mockLogger = mock<ILogger>()
 
-        AndroidOptionsInitializer.init(sentryOptions, mockContext)
+        AndroidOptionsInitializer.init(sentryOptions, mockContext, mockLogger)
         val actual = sentryOptions.eventProcessors.firstOrNull { it::class == DefaultAndroidEventProcessor::class }
         assertNotNull(actual)
     }


### PR DESCRIPTION
Overload to avoid instantiating `AndroidLogger` twice on a happy path