### PR TITLE
ref: Don't bypass certo validation by defau;t

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
@@ -9,7 +9,7 @@ class AsyncConnectionFactory {
     try {
       IConnectionConfigurator setCredentials = new CredentialsSettingConfigurator(options);
 
-      HttpTransport transport = new HttpTransport(options, null, setCredentials, 60, 60, true);
+      HttpTransport transport = new HttpTransport(options, null, setCredentials, 60, 60, false);
 
       // TODO this should be made configurable at least for the Android case where we can
       // just not attempt to send if the device is offline.


### PR DESCRIPTION
Certificate should be validated by default. We can optionally expose that flag via `SentryOptions` for self-hosted Sentry on `https` with self-signed certs.