### PR TITLE
fix sentry UTC timestamp

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/DateUtils.java
+++ b/sentry-core/src/main/java/io/sentry/core/DateUtils.java
@@ -3,7 +3,6 @@ package io.sentry.core;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -32,8 +31,8 @@ public class DateUtils {
    * @return the ISO UTC date and time
    */
   public static Date getCurrentDateTime() {
-    TimeZone tz = TimeZone.getTimeZone(UTC);
-    return Calendar.getInstance(tz).getTime();
+    String timestampIsoFormat = getTimestampIsoFormat(new Date());
+    return getDateTime(timestampIsoFormat);
   }
 
   /**

--- a/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
@@ -55,10 +55,6 @@ public class SentryEvent implements IUnknownPropertiesConsumer {
     return (Date) timestamp.clone();
   }
 
-  String getTimestampIsoFormat() {
-    return DateUtils.getTimestampIsoFormat(timestamp);
-  }
-
   Throwable getThrowable() {
     return throwable;
   }

--- a/sentry-core/src/test/java/io/sentry/core/SentryEventTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryEventTest.kt
@@ -7,7 +7,6 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Date
 import java.util.Locale
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -20,12 +19,11 @@ class SentryEventTest {
 
     @Test
     fun `constructor defines timestamp after now`() =
-            assertTrue(Instant.now().plus(1, ChronoUnit.HOURS).isAfter(SentryEvent().timestamp.toInstant()))
+            assertTrue(Instant.now().plus(1, ChronoUnit.HOURS).isAfter(Instant.parse(DateUtils.getTimestamp(SentryEvent().timestamp))))
 
     @Test
-    @Ignore("fix me")
     fun `constructor defines timestamp before hour ago`() =
-            assertTrue(Instant.now().minus(1, ChronoUnit.HOURS).isBefore(SentryEvent().timestamp.toInstant()))
+            assertTrue(Instant.now().minus(1, ChronoUnit.HOURS).isBefore(Instant.parse(DateUtils.getTimestamp(SentryEvent().timestamp))))
 
     @Test
     fun `timestamp is formatted in ISO 8601 in UTC with Z format`() {

--- a/sentry-core/src/test/java/io/sentry/core/SentryEventTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryEventTest.kt
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Date
 import java.util.Locale
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -22,6 +23,7 @@ class SentryEventTest {
             assertTrue(Instant.now().plus(1, ChronoUnit.HOURS).isAfter(SentryEvent().timestamp.toInstant()))
 
     @Test
+    @Ignore("fix me")
     fun `constructor defines timestamp before hour ago`() =
             assertTrue(Instant.now().minus(1, ChronoUnit.HOURS).isBefore(SentryEvent().timestamp.toInstant()))
 
@@ -32,6 +34,6 @@ class SentryEventTest {
         val formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ssX", Locale.ROOT)
         val date = OffsetDateTime.parse(expected, formatter)
         val actual = SentryEvent(null, Date(date.toInstant().toEpochMilli()))
-        assertEquals(expected, actual.timestampIsoFormat)
+        assertEquals(expected, DateUtils.getTimestampIsoFormat(actual.timestamp))
     }
 }

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="io.sentry.sample">
-
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <application
     android:allowBackup="false"
     android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
make timestamp in UTC


## :bulb: Motivation and Context
timestamp was not in UTC


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
