### PR TITLE
feat: Uncaught exception is captured

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/DiagnosticLogger.java
+++ b/sentry-core/src/main/java/io/sentry/core/DiagnosticLogger.java
@@ -16,7 +16,6 @@ public class DiagnosticLogger implements ILogger {
    */
   public DiagnosticLogger(SentryOptions options, @Nullable ILogger logger) {
     this.options = Objects.requireNonNull(options, "SentryOptions is required.");
-    ;
     this.logger = logger;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -31,6 +31,9 @@ public class Hub implements IHub, Cloneable {
     if (rootStackItem != null) {
       this.stack.push(rootStackItem);
     }
+    for (Integration integration : options.getIntegrations()) {
+      integration.register(this, options);
+    }
     this.isEnabled = true;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Integration.java
+++ b/sentry-core/src/main/java/io/sentry/core/Integration.java
@@ -1,0 +1,5 @@
+package io.sentry.core;
+
+public interface Integration {
+  void register(IHub hub, SentryOptions options);
+}

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -8,6 +8,7 @@ public class SentryOptions {
   static final SentryLevel DEFAULT_DIAGNOSTIC_LEVEL = SentryLevel.DEBUG;
 
   private List<EventProcessor> eventProcessors = new ArrayList<>();
+  private List<Integration> integrations = new ArrayList<>();
 
   private String dsn;
   private long shutdownTimeoutMills;
@@ -24,6 +25,14 @@ public class SentryOptions {
 
   public List<EventProcessor> getEventProcessors() {
     return eventProcessors;
+  }
+
+  public void addIntegration(Integration integration) {
+    integrations.add(integration);
+  }
+
+  public List<Integration> getIntegrations() {
+    return integrations;
   }
 
   public String getDsn() {
@@ -95,5 +104,9 @@ public class SentryOptions {
 
   public interface BeforeSecondCallback {
     SentryEvent execute(SentryEvent event);
+  }
+
+  public SentryOptions() {
+    integrations.add(new UncaughtExceptionHandlerIntegration());
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandler.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandler.java
@@ -12,7 +12,7 @@ interface UncaughtExceptionHandler {
       return Adapter.INSTANCE;
     }
 
-    final static Adapter INSTANCE = new Adapter();
+    static final Adapter INSTANCE = new Adapter();
 
     private Adapter() {}
 

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandler.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandler.java
@@ -1,0 +1,29 @@
+package io.sentry.core;
+
+/** An adapter to make UncaughtExceptionHandler testable */
+interface UncaughtExceptionHandler {
+  Thread.UncaughtExceptionHandler getDefaultUncaughtExceptionHandler();
+
+  void setDefaultUncaughtExceptionHandler(Thread.UncaughtExceptionHandler handler);
+
+  class Adapter implements UncaughtExceptionHandler {
+
+    UncaughtExceptionHandler getInstance() {
+      return Adapter.INSTANCE;
+    }
+
+    static Adapter INSTANCE = new Adapter();
+
+    private Adapter() {}
+
+    @Override
+    public Thread.UncaughtExceptionHandler getDefaultUncaughtExceptionHandler() {
+      return Thread.getDefaultUncaughtExceptionHandler();
+    }
+
+    @Override
+    public void setDefaultUncaughtExceptionHandler(Thread.UncaughtExceptionHandler handler) {
+      Thread.setDefaultUncaughtExceptionHandler(handler);
+    }
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -1,8 +1,8 @@
 package io.sentry.core;
 
-import io.sentry.core.util.Objects;
-
 import static io.sentry.core.ILogger.log;
+
+import io.sentry.core.util.Objects;
 
 /**
  * Sends any uncaught exception to Sentry, then passes the exception on to the pre-existing uncaught

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -1,0 +1,73 @@
+package io.sentry.core;
+
+import static io.sentry.core.ILogger.log;
+
+/**
+ * Sends any uncaught exception to Sentry, then passes the exception on to the pre-existing uncaught
+ * exception handler.
+ */
+public class UncaughtExceptionHandlerIntegration
+    implements Integration, Thread.UncaughtExceptionHandler {
+  /** Reference to the pre-existing uncaught exception handler. */
+  private Thread.UncaughtExceptionHandler defaultExceptionHandler;
+
+  private IHub hub;
+  private SentryOptions options;
+
+  private boolean isRegistered = false;
+  private UncaughtExceptionHandler threadAdapter;
+
+  public UncaughtExceptionHandlerIntegration() {
+    this(UncaughtExceptionHandler.Adapter.INSTANCE);
+  }
+
+  UncaughtExceptionHandlerIntegration(UncaughtExceptionHandler threadAdapter) {
+    if (threadAdapter == null) {
+      throw new IllegalArgumentException("threadAdapter is required.");
+    }
+
+    this.threadAdapter = threadAdapter;
+  }
+
+  @Override
+  public void register(IHub hub, SentryOptions options) {
+    if (isRegistered) {
+      log(
+          options.getLogger(),
+          SentryLevel.ERROR,
+          "Attempt to register a UncaughtExceptionHandlerIntegration twice. ");
+      return;
+    }
+    isRegistered = true;
+
+    this.hub = hub;
+    this.options = options;
+    Thread.UncaughtExceptionHandler currentHandler =
+        threadAdapter.getDefaultUncaughtExceptionHandler();
+    if (currentHandler != null) {
+      log(
+          options.getLogger(),
+          SentryLevel.DEBUG,
+          "default UncaughtExceptionHandler class='" + currentHandler.getClass().getName() + "'");
+      defaultExceptionHandler = currentHandler;
+    }
+
+    threadAdapter.setDefaultUncaughtExceptionHandler(this);
+  }
+
+  @Override
+  public void uncaughtException(Thread thread, Throwable thrown) {
+    log(options.getLogger(), SentryLevel.INFO, "Uncaught exception received.");
+
+    try {
+      // TODO: Set Thread info to the scope?
+      this.hub.captureException(thrown);
+    } catch (Exception e) {
+      log(options.getLogger(), SentryLevel.ERROR, "Error sending uncaught exception to Sentry.", e);
+    }
+
+    if (defaultExceptionHandler != null) {
+      defaultExceptionHandler.uncaughtException(thread, thrown);
+    }
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -1,5 +1,7 @@
 package io.sentry.core;
 
+import io.sentry.core.util.Objects;
+
 import static io.sentry.core.ILogger.log;
 
 /**
@@ -22,11 +24,7 @@ public class UncaughtExceptionHandlerIntegration
   }
 
   UncaughtExceptionHandlerIntegration(UncaughtExceptionHandler threadAdapter) {
-    if (threadAdapter == null) {
-      throw new IllegalArgumentException("threadAdapter is required.");
-    }
-
-    this.threadAdapter = threadAdapter;
+    this.threadAdapter = Objects.requireNonNull(threadAdapter, "threadAdapter is required.");
   }
 
   @Override

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -1,0 +1,17 @@
+package io.sentry.core
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import kotlin.test.Test
+
+class HubTest {
+    @Test
+    fun `when hub is initialized, integrations are registed`() {
+        val integrationMock = mock<Integration>()
+        val options = SentryOptions()
+        options.dsn = "https://key@sentry.io/proj"
+        options.addIntegration(integrationMock)
+        val expected = Hub(options)
+        verify(integrationMock).register(expected, options)
+    }
+}

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -38,6 +38,6 @@ class SentryOptionsTest {
 
     @Test
     fun `when options is initialized, integrations contain UncaughtExceptionHandlerIntegration`() {
-        assertTrue(SentryOptions().integrations.any { it::class.java == UncaughtExceptionHandlerIntegration::class.java })
+        assertTrue(SentryOptions().integrations.any { it is UncaughtExceptionHandlerIntegration })
     }
 }

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -3,6 +3,7 @@ package io.sentry.core
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull
 
 class SentryOptionsTest {
@@ -33,5 +34,10 @@ class SentryOptionsTest {
     @Test
     fun `when options is initialized, debug is false`() {
         assertFalse(SentryOptions().isDebug)
+    }
+
+    @Test
+    fun `when options is initialized, integrations contain UncaughtExceptionHandlerIntegration`() {
+        assertTrue(SentryOptions().integrations.any { it::class.java == UncaughtExceptionHandlerIntegration::class.java })
     }
 }

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -3,8 +3,8 @@ package io.sentry.core
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class SentryOptionsTest {
     @Test

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -8,30 +8,27 @@ import kotlin.test.Test
 
 class UncaughtExceptionHandlerIntegrationTest {
     @Test
-    fun `when UncaughtExceptionHandlerIntegration is initialized, uncaught handler is unchanged`()
-    {
+    fun `when UncaughtExceptionHandlerIntegration is initialized, uncaught handler is unchanged`() {
         val handlerMock = mock<UncaughtExceptionHandler>()
-        UncaughtExceptionHandlerIntegration(handlerMock);
+        UncaughtExceptionHandlerIntegration(handlerMock)
         verifyZeroInteractions(handlerMock)
     }
 
     @Test
-    fun `when uncaughtException is called, sentry captures exception`()
-    {
+    fun `when uncaughtException is called, sentry captures exception`() {
         val handlerMock = mock<UncaughtExceptionHandler>()
         val threadMock = mock<Thread>()
         val throwableMock = mock<Throwable>()
         val hubMock = mock<IHub>()
         val options = SentryOptions()
-        val sut = UncaughtExceptionHandlerIntegration(handlerMock);
+        val sut = UncaughtExceptionHandlerIntegration(handlerMock)
         sut.register(hubMock, options)
         sut.uncaughtException(threadMock, throwableMock)
         verify(hubMock).captureException(throwableMock)
     }
 
     @Test
-    fun `when register is called, current handler is not lost`()
-    {
+    fun `when register is called, current handler is not lost`() {
         val handlerMock = mock<UncaughtExceptionHandler>()
         val threadMock = mock<Thread>()
         val throwableMock = mock<Throwable>()
@@ -39,7 +36,7 @@ class UncaughtExceptionHandlerIntegrationTest {
         whenever(handlerMock.defaultUncaughtExceptionHandler).thenReturn(defaultHandlerMock)
         val hubMock = mock<IHub>()
         val options = SentryOptions()
-        val sut = UncaughtExceptionHandlerIntegration(handlerMock);
+        val sut = UncaughtExceptionHandlerIntegration(handlerMock)
         sut.register(hubMock, options)
         sut.uncaughtException(threadMock, throwableMock)
         verify(defaultHandlerMock).uncaughtException(threadMock, throwableMock)

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -1,0 +1,47 @@
+package io.sentry.core
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import kotlin.test.Test
+
+class UncaughtExceptionHandlerIntegrationTest {
+    @Test
+    fun `when UncaughtExceptionHandlerIntegration is initialized, uncaught handler is unchanged`()
+    {
+        val handlerMock = mock<UncaughtExceptionHandler>()
+        UncaughtExceptionHandlerIntegration(handlerMock);
+        verifyZeroInteractions(handlerMock)
+    }
+
+    @Test
+    fun `when uncaughtException is called, sentry captures exception`()
+    {
+        val handlerMock = mock<UncaughtExceptionHandler>()
+        val threadMock = mock<Thread>()
+        val throwableMock = mock<Throwable>()
+        val hubMock = mock<IHub>()
+        val options = SentryOptions()
+        val sut = UncaughtExceptionHandlerIntegration(handlerMock);
+        sut.register(hubMock, options)
+        sut.uncaughtException(threadMock, throwableMock)
+        verify(hubMock).captureException(throwableMock)
+    }
+
+    @Test
+    fun `when register is called, current handler is not lost`()
+    {
+        val handlerMock = mock<UncaughtExceptionHandler>()
+        val threadMock = mock<Thread>()
+        val throwableMock = mock<Throwable>()
+        val defaultHandlerMock = mock<Thread.UncaughtExceptionHandler>()
+        whenever(handlerMock.defaultUncaughtExceptionHandler).thenReturn(defaultHandlerMock)
+        val hubMock = mock<IHub>()
+        val options = SentryOptions()
+        val sut = UncaughtExceptionHandlerIntegration(handlerMock);
+        sut.register(hubMock, options)
+        sut.uncaughtException(threadMock, throwableMock)
+        verify(defaultHandlerMock).uncaughtException(threadMock, throwableMock)
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
SentryOptions exposes `Integrations`.
A default integration is added to capture uncaught exceptions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Basic sentry SDK feature

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
We could attemp unregisters but from what I recall when _unified API_ started @mitsuhiko was strongly against it.
If another integration also called `Thread.setDefaultUncaughtExceptionHandler` after we did, it wouldn't be possible to unregister, so that was the reason not to _pretend_ that we can unregister, even if best effort, and simply say: Once enabled, it's there for the lifetime of the app.
