### PR TITLE
added cacheDirPath to SentryOptions

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -3,6 +3,7 @@ package io.sentry.android.core;
 import android.content.Context;
 import io.sentry.core.ILogger;
 import io.sentry.core.SentryOptions;
+import java.io.File;
 
 class AndroidOptionsInitializer {
   static void init(SentryOptions options, Context context) {
@@ -17,7 +18,17 @@ class AndroidOptionsInitializer {
     options.setSentryClientName("sentry-android/0.0.1");
 
     ManifestMetadataReader.applyMetadata(context, options);
+    createsEnvelopeDirPath(options, context);
     options.addEventProcessor(new DefaultAndroidEventProcessor(context, options));
     options.setSerializer(new AndroidSerializer(options.getLogger()));
+  }
+
+  private static void createsEnvelopeDirPath(SentryOptions options, Context context) {
+    File cacheDir = context.getCacheDir().getAbsoluteFile();
+    File envelopesDir = new File(cacheDir, "sentry-envelopes");
+    if (!envelopesDir.exists()) {
+      envelopesDir.mkdirs();
+    }
+    options.setCacheDirPath(envelopesDir.getAbsolutePath());
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
@@ -57,7 +58,7 @@ class AndroidOptionsInitializerTest {
 
         AndroidOptionsInitializer.init(sentryOptions, mockContext, mockLogger)
 
-        assertEquals("${File.separator}cache${File.separator}sentry-envelopes", sentryOptions.cacheDirPath)
+        assertTrue(sentryOptions.cacheDirPath.endsWith("${File.separator}cache${File.separator}sentry-envelopes"))
     }
 
     private fun createMockContext(): Context {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -57,14 +57,14 @@ class AndroidOptionsInitializerTest {
 
         AndroidOptionsInitializer.init(sentryOptions, mockContext, mockLogger)
 
-        assertEquals("/cache/sentry-envelopes", sentryOptions.cacheDirPath)
+        assertEquals("${File.separator}cache${File.separator}sentry-envelopes", sentryOptions.cacheDirPath)
     }
 
     private fun createMockContext(): Context {
         val mockContext = mock<Context> {
             on { applicationContext } doReturn context
         }
-        whenever(mockContext.cacheDir).thenReturn(File("/cache"))
+        whenever(mockContext.cacheDir).thenReturn(File("${File.separator}cache"))
         return mockContext
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
@@ -143,7 +143,7 @@ class SentryInitProviderTest {
         val mockContext = mock<Context> {
             on { applicationContext } doReturn context
         }
-        whenever(mockContext.cacheDir).thenReturn(File("/cache"))
+        whenever(mockContext.cacheDir).thenReturn(File("${File.separator}cache"))
         return mockContext
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
@@ -12,6 +12,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.InvalidDsnException
 import io.sentry.core.Sentry
+import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -46,9 +47,7 @@ class SentryInitProviderTest {
         assertFalse(Sentry.isEnabled())
         providerInfo.authority = AUTHORITY
 
-        val mockContext = mock<Context> {
-            on { applicationContext } doReturn context
-        }
+        val mockContext = createMockContext()
         val metaData = Bundle()
         mockMetaData(mockContext, metaData)
 
@@ -66,9 +65,7 @@ class SentryInitProviderTest {
         assertFalse(Sentry.isEnabled())
         providerInfo.authority = AUTHORITY
 
-        val mockContext = mock<Context> {
-            on { applicationContext } doReturn context
-        }
+        val mockContext = createMockContext()
         val metaData = Bundle()
         mockMetaData(mockContext, metaData)
 
@@ -86,9 +83,7 @@ class SentryInitProviderTest {
         assertFalse(Sentry.isEnabled())
         providerInfo.authority = AUTHORITY
 
-        val mockContext = mock<Context> {
-            on { applicationContext } doReturn context
-        }
+        val mockContext = createMockContext()
         val metaData = Bundle()
         mockMetaData(mockContext, metaData)
 
@@ -106,9 +101,7 @@ class SentryInitProviderTest {
         assertFalse(Sentry.isEnabled())
         providerInfo.authority = AUTHORITY
 
-        val mockContext = mock<Context> {
-            on { applicationContext } doReturn context
-        }
+        val mockContext = createMockContext()
         val metaData = Bundle()
         mockMetaData(mockContext, metaData)
 
@@ -124,9 +117,7 @@ class SentryInitProviderTest {
         assertFalse(Sentry.isEnabled())
         providerInfo.authority = AUTHORITY
 
-        val mockContext = mock<Context> {
-            on { applicationContext } doReturn context
-        }
+        val mockContext = createMockContext()
         val metaData = Bundle()
         mockMetaData(mockContext, metaData)
 
@@ -146,6 +137,14 @@ class SentryInitProviderTest {
         whenever(mockPackageManager.getApplicationInfo(mockContext.packageName, PackageManager.GET_META_DATA)).thenReturn(mockApplicationInfo)
 
         mockApplicationInfo.metaData = metaData
+    }
+
+    private fun createMockContext(): Context {
+        val mockContext = mock<Context> {
+            on { applicationContext } doReturn context
+        }
+        whenever(mockContext.cacheDir).thenReturn(File("/cache"))
+        return mockContext
     }
 
     companion object {

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -17,6 +17,7 @@ public class SentryOptions {
   private ISerializer serializer;
   private String sentryClientName;
   private BeforeSecondCallback beforeSend;
+  private String cacheDirPath;
 
   public void addEventProcessor(EventProcessor eventProcessor) {
     eventProcessors.add(eventProcessor);
@@ -91,6 +92,14 @@ public class SentryOptions {
 
   public void setBeforeSend(BeforeSecondCallback beforeSend) {
     this.beforeSend = beforeSend;
+  }
+
+  public String getCacheDirPath() {
+    return cacheDirPath;
+  }
+
+  public void setCacheDirPath(String cacheDirPath) {
+    this.cacheDirPath = cacheDirPath;
   }
 
   public interface BeforeSecondCallback {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
added sentry cache dir folder to sentry options


## :bulb: Motivation and Context
NDK needs this path to create envelopes


## :green_heart: How did you test it?
unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
