### PR TITLE
feat: BeforeBreadcrumb

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -108,7 +108,13 @@ public class Hub implements IHub, Cloneable {
   public void addBreadcrumb(Breadcrumb breadcrumb) {
     StackItem item = stack.peek();
     if (item != null) {
-      item.scope.addBreadcrumb(breadcrumb);
+      SentryOptions.BeforeBreadcrumbCallback callback = options.getBeforeBreadcrumb();
+      if (callback != null) {
+        breadcrumb = callback.execute(breadcrumb);
+      }
+      if (breadcrumb != null) {
+        item.scope.addBreadcrumb(breadcrumb);
+      }
     } else {
       log(options.getLogger(), SentryLevel.FATAL, "Stack peek was NULL when addBreadcrumb");
     }

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -39,7 +39,7 @@ public class SentryClient implements ISentryClient {
       processor.process(event);
     }
 
-    SentryOptions.BeforeSecondCallback beforeSend = options.getBeforeSend();
+    SentryOptions.BeforeSendCallback beforeSend = options.getBeforeSend();
     if (beforeSend != null) {
       event = beforeSend.execute(event);
       if (event == null) {

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -18,7 +18,8 @@ public class SentryOptions {
   private SentryLevel diagnosticLevel = DEFAULT_DIAGNOSTIC_LEVEL;
   private ISerializer serializer;
   private String sentryClientName;
-  private BeforeSecondCallback beforeSend;
+  private BeforeSendCallback beforeSend;
+  private BeforeBreadcrumbCallback beforeBreadcrumb;
   private String cacheDirPath;
 
   public void addEventProcessor(EventProcessor eventProcessor) {
@@ -104,12 +105,20 @@ public class SentryOptions {
     this.sentryClientName = sentryClientName;
   }
 
-  public BeforeSecondCallback getBeforeSend() {
+  public BeforeSendCallback getBeforeSend() {
     return beforeSend;
   }
 
-  public void setBeforeSend(BeforeSecondCallback beforeSend) {
+  public void setBeforeSend(BeforeSendCallback beforeSend) {
     this.beforeSend = beforeSend;
+  }
+
+  public BeforeBreadcrumbCallback getBeforeBreadcrumb() {
+    return beforeBreadcrumb;
+  }
+
+  public void setBeforeBreadcrumb(BeforeBreadcrumbCallback beforeBreadcrumb) {
+    this.beforeBreadcrumb = beforeBreadcrumb;
   }
 
   public String getCacheDirPath() {
@@ -120,8 +129,12 @@ public class SentryOptions {
     this.cacheDirPath = cacheDirPath;
   }
 
-  public interface BeforeSecondCallback {
+  public interface BeforeSendCallback {
     SentryEvent execute(SentryEvent event);
+  }
+
+  public interface BeforeBreadcrumbCallback {
+    Breadcrumb execute(Breadcrumb breadcrumb);
   }
 
   public SentryOptions() {

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -37,12 +37,52 @@ class HubTest {
     }
 
     @Test
-    fun `when hub is initialized, integrations are registed`() {
+    fun `when hub is initialized, integrations are registered`() {
         val integrationMock = mock<Integration>()
         val options = SentryOptions()
         options.dsn = "https://key@sentry.io/proj"
         options.addIntegration(integrationMock)
         val expected = Hub(options)
         verify(integrationMock).register(expected, options)
+    }
+
+    @Test
+    fun `when beforeBreadcrumb returns null, crumb is dropped`() {
+        val options = SentryOptions()
+        options.beforeBreadcrumb = SentryOptions.BeforeBreadcrumbCallback { null }
+        options.dsn = "https://key@sentry.io/proj"
+        val sut = Hub(options)
+        sut.addBreadcrumb(Breadcrumb())
+        var breadcrumbs: List<Breadcrumb>? = null
+        sut.configureScope { breadcrumbs = it.breadcrumbs }
+        assertEquals(0, breadcrumbs!!.size)
+    }
+
+    @Test
+    fun `when beforeBreadcrumb modifies crumb, crumb is stored modified`() {
+        val options = SentryOptions()
+        val expected = "expected"
+        options.beforeBreadcrumb = SentryOptions.BeforeBreadcrumbCallback { it.message = expected; it }
+        options.dsn = "https://key@sentry.io/proj"
+        val sut = Hub(options)
+        var crumb = Breadcrumb()
+        crumb.message = "original"
+        sut.addBreadcrumb(crumb)
+        var breadcrumbs: List<Breadcrumb>? = null
+        sut.configureScope { breadcrumbs = it.breadcrumbs }
+        assertEquals(expected, breadcrumbs!!.first().message)
+    }
+
+    @Test
+    fun `when beforeBreadcrumb is null, crumb is stored`() {
+        val options = SentryOptions()
+        options.beforeBreadcrumb = null
+        options.dsn = "https://key@sentry.io/proj"
+        val sut = Hub(options)
+        var expected = Breadcrumb()
+        sut.addBreadcrumb(expected)
+        var breadcrumbs: List<Breadcrumb>? = null
+        sut.configureScope { breadcrumbs = it.breadcrumbs }
+        assertEquals(expected, breadcrumbs!!.single())
     }
 }


### PR DESCRIPTION
Callback executed before adding a breadcrumb to the scope.

Docs: https://docs.sentry.io/error-reporting/configuration/?platform=csharp#before-breadcrumb