### PR TITLE
[deferred] Implement flush in SentryClient.

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -200,7 +200,7 @@ public final class Hub implements IHub, Cloneable {
   }
 
   @Override
-  public void flush(long timeoutMills) {
+  public void flush(long timeoutMills) throws InterruptedException {
     StackItem item = stack.peek();
     if (item != null) {
       item.client.flush(timeoutMills);

--- a/sentry-core/src/main/java/io/sentry/core/IHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/IHub.java
@@ -28,7 +28,7 @@ public interface IHub {
 
   void bindClient(SentryClient client);
 
-  void flush(long timeoutMills);
+  void flush(long timeoutMills) throws InterruptedException;
 
   IHub clone();
 }

--- a/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
@@ -11,7 +11,7 @@ public interface ISentryClient {
 
   void close();
 
-  void flush(long timeoutMills);
+  void flush(long timeoutMills) throws InterruptedException;
 
   default SentryId captureEvent(SentryEvent event) {
     return captureEvent(event, null);

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -99,7 +99,7 @@ public final class Sentry {
     getCurrentHub().bindClient(client);
   }
 
-  public static void flush(int timeoutMills) {
+  public static void flush(int timeoutMills) throws InterruptedException {
     getCurrentHub().flush(timeoutMills);
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
@@ -7,7 +7,7 @@ import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.TestOnly;
 public final class AsyncConnection implements Closeable {
   private final ITransport transport;
   private final ITransportGate transportGate;
-  private final ExecutorService executor;
+  private final FlushableExecutorService executor;
   private final IEventCache eventCache;
   private final SentryOptions options;
 
@@ -43,7 +43,7 @@ public final class AsyncConnection implements Closeable {
       ITransport transport,
       ITransportGate transportGate,
       IEventCache eventCache,
-      ExecutorService executorService,
+      FlushableExecutorService executorService,
       SentryOptions options) {
     this.transport = transport;
     this.transportGate = transportGate;
@@ -84,6 +84,10 @@ public final class AsyncConnection implements Closeable {
   // https://errorprone.info/bugpattern/FutureReturnValueIgnored
   public void send(SentryEvent event) throws IOException {
     executor.submit(new EventSender(event));
+  }
+
+  public Future<Void> flush(long timeout, TimeUnit unit) {
+    return executor.flush(timeout, unit);
   }
 
   @Override

--- a/sentry-core/src/main/java/io/sentry/core/transport/FlushableExecutorService.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/FlushableExecutorService.java
@@ -1,0 +1,23 @@
+package io.sentry.core.transport;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/** This interface is not public because it is provided solely for the ease of testing. */
+interface FlushableExecutorService extends ExecutorService {
+
+  /**
+   * In essence, this is very similar to {@link #awaitTermination(long, TimeUnit)} but keeps the
+   * executor active.
+   *
+   * <p>New tasks can be submitted to the executor service. The return future completes when all the
+   * tasks queued at the time this method was called are finished.
+   *
+   * @param timeout the amount of time to wait for the flushing to finish
+   * @param unit the unit of the time
+   * @return a future that will complete as soon as all the tasks in the executor service are
+   *     completed or the timeout happens, whichever comes first.
+   */
+  Future<Void> flush(long timeout, TimeUnit unit);
+}

--- a/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
@@ -1,10 +1,12 @@
 package io.sentry.core
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.mockingDetails
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.protocol.User
 import io.sentry.core.transport.AsyncConnection
 import kotlin.test.Ignore
@@ -12,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.Before
 
 class SentryClientTest {
 
@@ -24,6 +27,11 @@ class SentryClientTest {
     }
 
     private val fixture = Fixture()
+
+    @Before
+    fun setup() {
+        whenever(fixture.connection.flush(any(), any())).thenReturn(mock())
+    }
 
     @Test
     fun `when fixture is unchanged, client is enabled`() {

--- a/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
@@ -12,7 +12,6 @@ import io.sentry.core.SentryEvent
 import io.sentry.core.SentryOptions
 import io.sentry.core.dsnString
 import java.io.IOException
-import java.util.concurrent.ExecutorService
 import kotlin.test.Test
 
 class AsyncConnectionTest {
@@ -21,7 +20,7 @@ class AsyncConnectionTest {
         var transport = mock<ITransport>()
         var transportGate = mock<ITransportGate>()
         var eventCache = mock<IEventCache>()
-        var executor = mock<ExecutorService>()
+        var executor = mock<FlushableExecutorService>()
         var sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Implement flushing of queued events in `SentryClient`.

Note that during the testing of this PR I found a race condition in the `RetryingThreadPoolExecutorTest` (just the test code, not the actual impl). It might be possible that the tests will hang when then stars align right. I ran the test suite over 300 times and encountered  1 such occurrence (which seems to be fixed by the changes in the `limits the queue size` test).

## :bulb: Motivation and Context
Flush is important for ensuring events are sent.

## :green_heart: How did you test it?
by unit tests

## :pencil: Checklist
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
