### PR TITLE
Implementation of DiskCache and the ability to store events before sending

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -24,6 +24,7 @@ public final class SentryOptions {
   private BeforeSendCallback beforeSend;
   private BeforeBreadcrumbCallback beforeBreadcrumb;
   private String cacheDirPath;
+  private int cacheDirSize;
   private int maxBreadcrumbs = 100;
   private String release;
   private String environment;
@@ -141,6 +142,14 @@ public final class SentryOptions {
 
   public void setCacheDirPath(String cacheDirPath) {
     this.cacheDirPath = cacheDirPath;
+  }
+
+  public int getCacheDirSize() {
+    return cacheDirSize;
+  }
+
+  public void setCacheDirSize(int cacheDirSize) {
+    this.cacheDirSize = cacheDirSize;
   }
 
   public int getMaxBreadcrumbs() {

--- a/sentry-core/src/main/java/io/sentry/core/cache/DiskCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/DiskCache.java
@@ -1,0 +1,152 @@
+package io.sentry.core.cache;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+import static io.sentry.core.ILogger.logIfNotNull;
+import static io.sentry.core.SentryLevel.DEBUG;
+import static io.sentry.core.SentryLevel.ERROR;
+import static io.sentry.core.SentryLevel.WARNING;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import io.sentry.core.ISerializer;
+import io.sentry.core.SentryEvent;
+import io.sentry.core.SentryLevel;
+import io.sentry.core.SentryOptions;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A simple cache implementation storing the events to a disk, each event in a separater file in a configured directory.
+ */
+public final class DiskCache implements IEventCache {
+  /**
+   * File suffix added to all serialized event files.
+   */
+  public static final String FILE_SUFFIX = ".sentry-event";
+
+  @SuppressWarnings("CharsetObjectCanBeUsed")
+  private static final Charset UTF8 = Charset.forName("UTF-8");
+
+  private final File directory;
+  private final int maxSize;
+  private final ISerializer serializer;
+  private final SentryOptions options;
+
+  public DiskCache(SentryOptions options) {
+    this.directory = new File(options.getCacheDirPath());
+    this.maxSize = options.getCacheDirSize();
+    this.serializer = options.getSerializer();
+    this.options = options;
+
+    try {
+      //noinspection ResultOfMethodCallIgnored
+      directory.mkdirs();
+      checkDirectoryValid();
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to initialize the directory for caching Sentry events.", e);
+    }
+  }
+
+  @Override
+  public void store(SentryEvent event) {
+    if (getNumberOfStoredEvents() >= maxSize) {
+      logIfNotNull(options.getLogger(), SentryLevel.WARNING, "Disk cache full. Not storing event {}", event);
+      return;
+    }
+
+    File eventFile = getEventFile(event);
+    if (eventFile.exists()) {
+      logIfNotNull(options.getLogger(), DEBUG,
+        "Not adding Event to offline storage because it already exists: %s", eventFile.getAbsolutePath());
+      return;
+    } else {
+      logIfNotNull(options.getLogger(), DEBUG, "Adding Event to offline storage: %s", eventFile.getAbsolutePath());
+    }
+
+    try (FileOutputStream fileOutputStream = new FileOutputStream(eventFile);
+         Writer wrt = new OutputStreamWriter(fileOutputStream, UTF8)) {
+      serializer.serialize(event, wrt);
+    } catch (Exception e) {
+      logIfNotNull(options.getLogger(), ERROR, "Error writing Event to offline storage: %s", event.getEventId());
+    }
+  }
+
+  @Override
+  public void discard(SentryEvent event) {
+    File eventFile = getEventFile(event);
+        if (eventFile.exists()) {
+            logIfNotNull(options.getLogger(), DEBUG, "Discarding event from cache: %s",
+              eventFile.getAbsolutePath());
+
+            if (!eventFile.delete()) {
+                logIfNotNull(options.getLogger(), WARNING, "Failed to delete Event: %s", eventFile.getAbsolutePath());
+            }
+        } else {
+          logIfNotNull(options.getLogger(), DEBUG, "Event was not cached: %s", eventFile.getAbsolutePath());
+        }
+  }
+
+  private int getNumberOfStoredEvents() {
+    return allEventFiles().length;
+  }
+
+  private void checkDirectoryValid() {
+    if (!directory.isDirectory() || !directory.canWrite() || !directory.canRead()) {
+      throw new IllegalStateException("The directory for caching Sentry events is inaccessible.");
+    }
+  }
+
+  private File getEventFile(SentryEvent event) {
+    return new File(directory.getAbsolutePath(), event.getEventId().toString() + FILE_SUFFIX);
+  }
+
+  @NotNull
+  @Override
+  public Iterator<SentryEvent> iterator() {
+    File[] allCachedEvents = allEventFiles();
+
+    List<SentryEvent> ret = new ArrayList<>(allCachedEvents.length);
+
+    char[] buffer = new char[1024];
+    for (File f : allCachedEvents) {
+      try (InputStreamReader rdr = new InputStreamReader(new BufferedInputStream(new FileInputStream(f)), UTF8)) {
+
+        int cnt;
+        StringBuilder bld = new StringBuilder();
+        while ((cnt = rdr.read(buffer)) != -1) {
+          bld.append(buffer, 0, cnt);
+        }
+
+        ret.add(serializer.deserializeEvent(bld.toString()));
+      } catch (FileNotFoundException e) {
+        logIfNotNull(options.getLogger(), DEBUG, "Event file '%s' disappeared while converting all cached files to events.",
+          f.getAbsolutePath());
+      } catch (IOException e) {
+        logIfNotNull(options.getLogger(), ERROR,
+          format("Error while reading cached event from file %s", f.getAbsolutePath()), e);
+      }
+    }
+
+    return ret.iterator();
+  }
+
+  private File[] allEventFiles() {
+    checkDirectoryValid();
+    return requireNonNull(directory.listFiles((__, fileName) -> fileName.endsWith(FILE_SUFFIX)));
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/cache/IEventCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/IEventCache.java
@@ -1,4 +1,4 @@
-package io.sentry.core.transport;
+package io.sentry.core.cache;
 
 import io.sentry.core.SentryEvent;
 
@@ -10,7 +10,7 @@ import io.sentry.core.SentryEvent;
  * crash. While that is surely one of the main usecases for the persistent storage of events, the
  * re-initialization is out of scope of the event transport logic.
  */
-public interface IEventCache {
+public interface IEventCache extends Iterable<SentryEvent> {
 
   /**
    * Stores the event so that it can be sent later.

--- a/sentry-core/src/test/java/io/sentry/core/cache/DiskCacheTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/cache/DiskCacheTest.kt
@@ -1,0 +1,112 @@
+package io.sentry.core.cache
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.core.ISerializer
+import io.sentry.core.SentryEvent
+import io.sentry.core.SentryOptions
+import io.sentry.core.protocol.SentryId
+import java.io.Writer
+import java.nio.file.Files
+import java.util.*
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DiskCacheTest {
+    private class Fixture {
+        var maxSize = 5
+        var dir = Files.createTempDirectory("sentry-disk-cache-test")
+
+        fun getSUT(): DiskCache {
+            val options = SentryOptions()
+            options.cacheDirSize = maxSize
+            options.cacheDirPath = dir.toAbsolutePath().toFile().absolutePath
+
+            val serializer = mock<ISerializer>()
+            doAnswer {
+                val event = it.arguments[0] as SentryEvent
+                val writer = it.arguments[1] as Writer
+
+                writer.write(event.eventId.toString())
+            }.whenever(serializer).serialize(any(), any())
+
+            whenever(serializer.deserializeEvent(any())).thenAnswer {
+                val envelope = it.arguments[0] as String
+
+                val ret = SentryEvent()
+                ret.eventId = SentryId(envelope)
+                ret
+            }
+
+            options.serializer = serializer
+
+            return DiskCache(options)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @AfterTest
+    fun cleanUp() {
+        fixture.dir.toFile().listFiles()?.forEach { it.delete() }
+        Files.delete(fixture.dir)
+    }
+
+    @Test
+    fun `stores events`() {
+        val cache = fixture.getSUT()
+
+        val nofFiles = { fixture.dir.toFile().list()?.size }
+
+        assertEquals(0, nofFiles())
+
+        cache.store(SentryEvent())
+
+        assertEquals(1, nofFiles())
+    }
+
+    @Test
+    fun `limits the number of stored events`() {
+        val cache = fixture.getSUT()
+
+        val nofFiles = { fixture.dir.toFile().list()?.size }
+
+        assertEquals(0, nofFiles())
+
+        (1..fixture.maxSize + 1).forEach {
+            cache.store(SentryEvent(Exception()))
+        }
+
+        assertEquals(fixture.maxSize, nofFiles())
+    }
+
+    @Test
+    fun `tolerates discarding unknown event`() {
+        val cache = fixture.getSUT()
+
+        cache.discard(SentryEvent())
+
+        // no exception thrown
+    }
+
+    @Test
+    fun `reads the event back`() {
+
+        val cache = fixture.getSUT()
+
+        val event = SentryEvent()
+
+        cache.store(event)
+
+        val readEvents = cache.toList()
+
+        assertEquals(1, readEvents.size)
+
+        val readEvent = readEvents[0]
+
+        assertEquals(event.eventId.toString(), readEvent.eventId.toString())
+    }
+}

--- a/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
@@ -10,6 +10,7 @@ import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.SentryEvent
 import io.sentry.core.SentryOptions
+import io.sentry.core.cache.IEventCache
 import io.sentry.core.dsnString
 import java.io.IOException
 import java.util.concurrent.ExecutorService
@@ -34,7 +35,7 @@ class AsyncConnectionTest {
         }
 
         fun getSUT(): AsyncConnection {
-            return AsyncConnection(transport, transportGate, eventCache, executor, sentryOptions)
+            return AsyncConnection(transport, transportGate, eventCache, executor, true, sentryOptions)
         }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
This adds the implementation of the `IEventCache` interface that stores the data to the filesystem.
Also it adds a simple ability of the `AsyncConnection` to store the events before attempting to send.
The implementation of the `DiskCache` is largely copied from `sentry-java`.

While a new config property governing the maximum of cached events is added in this PR, the user has no choice in selecting the implementation of the cache. Maybe this should be changed?

## :bulb: Motivation and Context
We need this to be able to persist the events before sending to enable crash/kill recovery.

## :green_heart: How did you test it?
Just unit tests, no testing on a real/simulated Android device

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
- [ ] add ability to set the `IEventCache` implementation in `SentryOptions` as it is done for `ISerializer`?
- [ ] is sharing the threadpool for sending and storing events the right thing to do?
