### PR TITLE
feat: Uncaught event is persisted synchronously

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
@@ -5,7 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 final class AsyncConnectionFactory {
-  public static AsyncConnection create(SentryOptions options) {
+  public static AsyncConnection create(SentryOptions options, IEventCache eventCache) {
     try {
       Dsn parsedDsn = new Dsn(options.getDsn());
       IConnectionConfigurator setCredentials =
@@ -22,19 +22,9 @@ final class AsyncConnectionFactory {
 
       IBackOffIntervalStrategy linearBackoff = attempt -> attempt * 500;
 
-      // TODO this is obviously provisional and should be constructed based on the config in options
-      IEventCache blackHole =
-          new IEventCache() {
-            @Override
-            public void store(SentryEvent event) {}
-
-            @Override
-            public void discard(SentryEvent event) {}
-          };
-
       // the connection doesn't do any retries of failed sends and can hold at most 10
       // pending events. The rest is dropped.
-      return new AsyncConnection(transport, alwaysOn, linearBackoff, blackHole, 0, 10, options);
+      return new AsyncConnection(transport, alwaysOn, linearBackoff, eventCache, 0, 10, options);
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException(
           "Failed to compose the connection to the Sentry server.", e);

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -3,7 +3,9 @@ package io.sentry.core;
 import static io.sentry.core.ILogger.logIfNotNull;
 
 import io.sentry.core.protocol.SentryId;
-import io.sentry.core.transport.AsyncConnection;
+import io.sentry.core.transport.Connection;
+import io.sentry.core.transport.CrashedEventStore;
+import io.sentry.core.transport.IEventCache;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -19,7 +21,7 @@ public final class SentryClient implements ISentryClient {
   private boolean isEnabled;
 
   private final SentryOptions options;
-  private final AsyncConnection connection;
+  private final Connection connection;
   private final Random random;
 
   @Override
@@ -31,11 +33,23 @@ public final class SentryClient implements ISentryClient {
     this(options, null);
   }
 
-  public SentryClient(SentryOptions options, @Nullable AsyncConnection connection) {
+  public SentryClient(SentryOptions options, @Nullable Connection connection) {
     this.options = options;
     this.isEnabled = true;
     if (connection == null) {
-      connection = AsyncConnectionFactory.create(options);
+
+      // TODO this is obviously provisional and should be constructed based on the config in options
+      IEventCache blackHole =
+          new IEventCache() {
+            @Override
+            public void store(SentryEvent event) {}
+
+            @Override
+            public void discard(SentryEvent event) {}
+          };
+
+      connection =
+          new CrashedEventStore(AsyncConnectionFactory.create(options, blackHole), blackHole);
     }
     this.connection = connection;
     random = options.getSampling() == null ? null : new Random();

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -63,9 +63,8 @@ public final class UncaughtExceptionHandlerIntegration
 
     try {
       Throwable throwable = getUnhandledThrowable(thread, thrown);
+      // SDK is expected to write to disk synchronously events that crash the process
       this.hub.captureException(throwable);
-      // Close the SDK to flush the event to disk before shutting down.
-      this.hub.close();
     } catch (Exception e) {
       logIfNotNull(
           options.getLogger(), SentryLevel.ERROR, "Error sending uncaught exception to Sentry.", e);

--- a/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
 /** A connection to Sentry that sends the events asynchronously. */
-public final class AsyncConnection implements Closeable {
+public final class AsyncConnection implements Closeable, Connection {
   private final ITransport transport;
   private final ITransportGate transportGate;
   private final ExecutorService executor;
@@ -82,6 +82,7 @@ public final class AsyncConnection implements Closeable {
    */
   @SuppressWarnings("FutureReturnValueIgnored") // TODO:
   // https://errorprone.info/bugpattern/FutureReturnValueIgnored
+  @Override
   public void send(SentryEvent event) throws IOException {
     executor.submit(new EventSender(event));
   }

--- a/sentry-core/src/main/java/io/sentry/core/transport/Connection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/Connection.java
@@ -1,0 +1,10 @@
+package io.sentry.core.transport;
+
+import io.sentry.core.SentryEvent;
+import java.io.IOException;
+
+public interface Connection {
+  void send(SentryEvent event) throws IOException;
+
+  void close() throws IOException;
+}

--- a/sentry-core/src/main/java/io/sentry/core/transport/CrashedEventStore.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/CrashedEventStore.java
@@ -1,0 +1,40 @@
+package io.sentry.core.transport;
+
+import io.sentry.core.SentryEvent;
+import io.sentry.core.protocol.SentryThread;
+import io.sentry.core.util.Objects;
+import java.io.IOException;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+// TODO: not to be public and better naming
+public final class CrashedEventStore implements Connection {
+
+  private Connection inner;
+  private IEventCache eventCache;
+
+  public CrashedEventStore(Connection inner, IEventCache eventCache) {
+    this.inner = Objects.requireNonNull(inner, "The inner connection is required.");
+    this.eventCache = Objects.requireNonNull(eventCache, "The EventCache is required.");
+  }
+
+  @Override
+  public void send(@NotNull SentryEvent event) throws IOException {
+    List<SentryThread> threads = event.getThreads();
+    if (threads != null) {
+      for (SentryThread thread : threads) {
+        if (Boolean.TRUE.equals(thread.getCrashed())) {
+          eventCache.store(event);
+          return;
+        }
+      }
+    }
+
+    inner.send(event);
+  }
+
+  @Override
+  public void close() throws IOException {
+    inner.close();
+  }
+}

--- a/sentry-core/src/test/java/io/sentry/core/transport/CrashedEventStoreTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/CrashedEventStoreTest.kt
@@ -1,0 +1,42 @@
+package io.sentry.core.transport
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import io.sentry.core.SentryEvent
+import io.sentry.core.protocol.SentryThread
+import kotlin.test.Test
+
+class CrashedEventStoreTest {
+
+    class Fixture {
+        val connection = mock<Connection>()
+        val eventCache = mock<IEventCache>()
+        fun getSut() = CrashedEventStore(connection, eventCache)
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `when event includes a crashed thread, event is persisted`() {
+        val sut = fixture.getSut()
+        val actual = SentryEvent().apply {
+            threads = listOf(SentryThread().apply { crashed = true })
+        }
+        sut.send(actual)
+        verify(fixture.eventCache).store(actual)
+        verify(fixture.connection, never()).send(any())
+    }
+
+    @Test
+    fun `when event doesn't include a crashed thread, event is passed to inner connection`() {
+        val sut = fixture.getSut()
+        val actual = SentryEvent().apply {
+            threads = listOf(SentryThread().apply { crashed = false })
+        }
+        sut.send(actual)
+        verify(fixture.connection).send(actual)
+        verify(fixture.eventCache, never()).store(actual)
+    }
+}


### PR DESCRIPTION
Naming here not far from ideal.
We need to  discuss what a `Connection` is and a `Transport` is. Ideally in a separate PR. 
I suggest we get the behavior in, and refactor this since it'll involve changing the `AsyncConnection` and `HttpTransport`.

Follow up PR with a proposal will follow.