### PR TITLE
feat: Hint

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -23,6 +23,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.*;
+import org.jetbrains.annotations.Nullable;
 
 public final class DefaultAndroidEventProcessor implements EventProcessor {
 
@@ -43,7 +44,7 @@ public final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   @Override
-  public SentryEvent process(SentryEvent event) {
+  public SentryEvent process(SentryEvent event, @Nullable Object hint) {
     if (event.getSdk() == null) {
       event.setSdk(getSdkVersion());
     }

--- a/sentry-core/src/main/java/io/sentry/core/EventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/EventProcessor.java
@@ -1,5 +1,7 @@
 package io.sentry.core;
 
+import org.jetbrains.annotations.Nullable;
+
 public interface EventProcessor {
-  SentryEvent process(SentryEvent event);
+  SentryEvent process(SentryEvent event, @Nullable Object hint);
 }

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -64,7 +64,7 @@ public final class Hub implements IHub {
 
   @NotNull
   @Override
-  public SentryId captureEvent(SentryEvent event) {
+  public SentryId captureEvent(SentryEvent event, @Nullable Object hint) {
     SentryId sentryId = SentryId.EMPTY_ID;
     if (!isEnabled()) {
       logIfNotNull(
@@ -78,7 +78,7 @@ public final class Hub implements IHub {
       try {
         StackItem item = stack.peek();
         if (item != null) {
-          sentryId = item.client.captureEvent(event, item.scope);
+          sentryId = item.client.captureEvent(event, item.scope, hint);
         } else {
           logIfNotNull(
               options.getLogger(), SentryLevel.FATAL, "Stack peek was null when captureEvent");
@@ -127,7 +127,7 @@ public final class Hub implements IHub {
 
   @NotNull
   @Override
-  public SentryId captureException(Throwable throwable) {
+  public SentryId captureException(Throwable throwable, @Nullable Object hint) {
     SentryId sentryId = SentryId.EMPTY_ID;
     if (!isEnabled()) {
       logIfNotNull(

--- a/sentry-core/src/main/java/io/sentry/core/IHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/IHub.java
@@ -7,11 +7,19 @@ public interface IHub extends Cloneable {
 
   boolean isEnabled();
 
-  SentryId captureEvent(SentryEvent event);
+  SentryId captureEvent(SentryEvent event, @Nullable Object hint);
+
+  default SentryId captureEvent(SentryEvent event) {
+    return captureEvent(event, null);
+  }
 
   SentryId captureMessage(String message);
 
-  SentryId captureException(Throwable throwable);
+  SentryId captureException(Throwable throwable, @Nullable Object hint);
+
+  default SentryId captureException(Throwable throwable) {
+    return captureException(throwable, null);
+  }
 
   void close();
 

--- a/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
@@ -7,14 +7,22 @@ import org.jetbrains.annotations.Nullable;
 public interface ISentryClient {
   boolean isEnabled();
 
-  SentryId captureEvent(SentryEvent event, @Nullable Scope scope);
+  SentryId captureEvent(SentryEvent event, @Nullable Scope scope, @Nullable Object hint);
 
   void close();
 
   void flush(long timeoutMills);
 
   default SentryId captureEvent(SentryEvent event) {
-    return captureEvent(event, null);
+    return captureEvent(event, null, null);
+  }
+
+  default SentryId captureEvent(SentryEvent event, @Nullable Scope scope) {
+    return captureEvent(event, scope, null);
+  }
+
+  default SentryId captureEvent(SentryEvent event, @Nullable Object hint) {
+    return captureEvent(event, null, hint);
   }
 
   default SentryId captureMessage(String message) {
@@ -30,11 +38,20 @@ public interface ISentryClient {
   }
 
   default SentryId captureException(Throwable throwable) {
-    return captureException(throwable, null);
+    return captureException(throwable, null, null);
+  }
+
+  default SentryId captureException(
+      Throwable throwable, @Nullable Scope scope, @Nullable Object hint) {
+    SentryEvent event = new SentryEvent(throwable);
+    return captureEvent(event, scope, hint);
+  }
+
+  default SentryId captureException(Throwable throwable, @Nullable Object hint) {
+    return captureException(throwable, null, hint);
   }
 
   default SentryId captureException(Throwable throwable, @Nullable Scope scope) {
-    SentryEvent event = new SentryEvent(throwable);
-    return captureEvent(event, scope);
+    return captureException(throwable, scope, null);
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.core;
 import io.sentry.core.protocol.SentryException;
 import io.sentry.core.util.Objects;
 import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
 public final class MainEventProcessor implements EventProcessor {
 
@@ -32,7 +33,7 @@ public final class MainEventProcessor implements EventProcessor {
   }
 
   @Override
-  public SentryEvent process(SentryEvent event) {
+  public SentryEvent process(SentryEvent event, @Nullable Object hint) {
     if (event.getRelease() == null) {
       event.setRelease(options.getRelease());
     }

--- a/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
@@ -19,7 +19,7 @@ final class NoOpHub implements IHub {
   }
 
   @Override
-  public SentryId captureEvent(SentryEvent event) {
+  public SentryId captureEvent(SentryEvent event, @Nullable Object hint) {
     return SentryId.EMPTY_ID;
   }
 
@@ -29,7 +29,7 @@ final class NoOpHub implements IHub {
   }
 
   @Override
-  public SentryId captureException(Throwable throwable) {
+  public SentryId captureException(Throwable throwable, @Nullable Object hint) {
     return SentryId.EMPTY_ID;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
@@ -19,32 +19,7 @@ final class NoOpSentryClient implements ISentryClient {
   }
 
   @Override
-  public SentryId captureEvent(SentryEvent event) {
-    return SentryId.EMPTY_ID;
-  }
-
-  @Override
-  public SentryId captureEvent(SentryEvent event, Scope scope) {
-    return SentryId.EMPTY_ID;
-  }
-
-  @Override
-  public SentryId captureMessage(String message) {
-    return SentryId.EMPTY_ID;
-  }
-
-  @Override
-  public SentryId captureMessage(String message, @Nullable Scope scope) {
-    return SentryId.EMPTY_ID;
-  }
-
-  @Override
-  public SentryId captureException(Throwable throwable, @Nullable Scope scope) {
-    return SentryId.EMPTY_ID;
-  }
-
-  @Override
-  public SentryId captureException(Throwable throwable) {
+  public SentryId captureEvent(SentryEvent event, @Nullable Scope scope, @Nullable Object hint) {
     return SentryId.EMPTY_ID;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -64,12 +64,20 @@ public final class Sentry {
     return getCurrentHub().captureEvent(event);
   }
 
+  public static SentryId captureEvent(SentryEvent event, @Nullable Object hint) {
+    return getCurrentHub().captureEvent(event, hint);
+  }
+
   public static SentryId captureMessage(String message) {
     return getCurrentHub().captureMessage(message);
   }
 
   public static SentryId captureException(Throwable throwable) {
     return getCurrentHub().captureException(throwable);
+  }
+
+  public static SentryId captureException(Throwable throwable, @Nullable Object hint) {
+    return getCurrentHub().captureException(throwable, hint);
   }
 
   public static void addBreadcrumb(Breadcrumb breadcrumb, @Nullable Object hint) {

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -42,7 +42,7 @@ public final class SentryClient implements ISentryClient {
   }
 
   @Override
-  public SentryId captureEvent(SentryEvent event, @Nullable Scope scope) {
+  public SentryId captureEvent(SentryEvent event, @Nullable Scope scope, @Nullable Object hint) {
     if (!sample()) {
       logIfNotNull(
           options.getLogger(),
@@ -94,11 +94,10 @@ public final class SentryClient implements ISentryClient {
     }
 
     for (EventProcessor processor : options.getEventProcessors()) {
-      processor.process(event);
+      processor.process(event, hint);
     }
 
-    // TODO: captureEvent now takes Hint too?
-    event = executeBeforeSend(event, null);
+    event = executeBeforeSend(event, hint);
 
     if (event == null) {
       // Event dropped by the beforeSend callback
@@ -144,11 +143,6 @@ public final class SentryClient implements ISentryClient {
       }
     }
     return event;
-  }
-
-  @Override
-  public SentryId captureEvent(SentryEvent event) {
-    return captureEvent(event, null);
   }
 
   @Override

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -239,8 +239,10 @@ class HubTest {
         val mockClient = mock<ISentryClient>()
         sut.bindClient(mockClient)
 
-        sut.captureEvent(SentryEvent())
-        verify(mockClient, times(1)).captureEvent(any(), any())
+        val event = SentryEvent()
+        val hint = { }
+        sut.captureEvent(event, hint)
+        verify(mockClient, times(1)).captureEvent(eq(event), any(), eq(hint))
     }
     //endregion
 

--- a/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
@@ -24,7 +24,7 @@ class MainEventProcessorTest {
         val mockThrowable = mock<Throwable>()
         val actualThrowable = UncaughtExceptionHandlerIntegration.getUnhandledThrowable(crashedThread, mockThrowable)
         val event = SentryEvent().apply { throwable = actualThrowable }
-        sut.process(event)
+        sut.process(event, null)
 
         assertSame(crashedThread.id, event.exceptions.first().threadId)
         assertTrue(event.threads.first { t -> t.id == crashedThread.id }.crashed)


### PR DESCRIPTION
Propagate `hint` from `Sentry` `captureEvent` and `captureException` to `Hub`, `SentryClient` and `EventProcessor`s.

We'll need this for ANR and UncaughtEH. And when capturing events cached on disk.