### PR TITLE
feat: Keep SentryNdk which is used via reflection

### DIFF
--- a/sentry-android-ndk/proguard-rules.pro
+++ b/sentry-android-ndk/proguard-rules.pro
@@ -1,1 +1,1 @@
-# how to set proguard rules for ndk https://proandroiddev.com/debugging-native-crashes-in-android-apps-2b86fd7113d8
+-keep class io.sentry.ndk.SentryNdk

--- a/sentry-android-ndk/proguard-rules.pro
+++ b/sentry-android-ndk/proguard-rules.pro
@@ -1,1 +1,10 @@
--keep class io.sentry.ndk.SentryNdk
+##---------------Begin: proguard configuration for NDK  ----------
+
+-keep class io.sentry.ndk.** { <fields>; }
+
+# For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+##---------------End: proguard configuration for NDK  ----------


### PR DESCRIPTION
Only class used via reflection so far is `SentryNdk`.
The native layer isn't calling a anything via JNI. 
So the only rule we need **so far** is in this PR.

We need to review changes to `sentry-android-ndk` so that types used via reflection or JNI calls from native get added too.