### PR TITLE
missing timestamp for breadcrumbs

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
+++ b/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
@@ -17,12 +17,12 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
   private SentryLevel level;
   private Map<String, Object> unknown;
 
-  public Breadcrumb(Date timestamp) {
+  Breadcrumb(Date timestamp) {
     this.timestamp = timestamp;
   }
 
   public Breadcrumb() {
-    timestamp = DateUtils.getCurrentDateTime();
+    this(DateUtils.getCurrentDateTime());
   }
 
   public Date getTimestamp() {

--- a/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
+++ b/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
@@ -17,8 +17,16 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
   private SentryLevel level;
   private Map<String, Object> unknown;
 
+  public Breadcrumb(Date timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public Breadcrumb() {
+    timestamp = DateUtils.getCurrentDateTime();
+  }
+
   public Date getTimestamp() {
-    return timestamp;
+    return (Date) timestamp.clone();
   }
 
   public void setTimestamp(Date timestamp) {

--- a/sentry-core/src/main/java/io/sentry/core/protocol/App.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/App.java
@@ -27,7 +27,7 @@ public final class App implements IUnknownPropertiesConsumer {
   }
 
   public Date getAppStartTime() {
-    return appStartTime;
+    return appStartTime != null ? (Date) appStartTime.clone() : null;
   }
 
   public void setAppStartTime(Date appStartTime) {

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Device.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Device.java
@@ -250,7 +250,7 @@ public final class Device implements IUnknownPropertiesConsumer {
   }
 
   public Date getBootTime() {
-    return bootTime;
+    return bootTime != null ? (Date) bootTime.clone() : null;
   }
 
   public void setBootTime(Date bootTime) {

--- a/sentry-core/src/test/java/io/sentry/core/BreadcrumbTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/BreadcrumbTest.kt
@@ -98,4 +98,10 @@ class BreadcrumbTest {
         assertEquals("category", clone.category)
         assertEquals(dateIso, DateUtils.getTimestamp(clone.timestamp))
     }
+
+    @Test
+    fun `breadcrumb has timestamp when created`() {
+        val breadcrumb = Breadcrumb()
+        assertNotNull(breadcrumb.timestamp)
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
added timestamp by default for breadcrumbs


## :bulb: Motivation and Context
timestamp was missing for breadcrumbs


## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
