### PR TITLE
debug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ cache:
   - "%USERPROFILE%\\.gradle\\wrapper"
   - "%USERPROFILE%\\.m2\\repository"
 build_script:
-  - cmd: gradlew.bat assemble check
+  - cmd: gradlew.bat build
 artifacts:
   - path: '**\libs\*sentry*.jar'
   - path: '**\outputs\aar\*sentry*.aar'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to sentry-android
+
+We love pull requests from everyone.
+
+The project currently requires you run JDK version `1.8.x`.
+
+To install spotlessCheck pre-commit hook:
+
+```shell
+git config core.hooksPath hooks/
+```
+
+To run the build and tests:
+
+```shell
+./gradlew build
+```
+
+Build and tests are automatically run against branches and pull requests
+via TravisCI and AppVeyor.

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -31,7 +31,7 @@ object Config {
         val androidxCore = "androidx.test:core:$androidxTestVersion"
         val androidxRunner = "androidx.test:runner:$androidxTestVersion"
         val androidxJunit = "androidx.test.ext:junit:1.1.1"
-        val robolectric = "org.robolectric:robolectric:4.3"
+        val robolectric = "org.robolectric:robolectric:4.3.1"
         val junit = "junit:junit:4.12"
         val espressoCore = "androidx.test.espresso:espresso-core:3.2.0"
         val androidxOrchestrator = "androidx.test:orchestrator:$androidxTestVersion"
@@ -39,7 +39,7 @@ object Config {
     }
 
     object QualityPlugins {
-        val jacocoVersion = "0.8.4"
+        val jacocoVersion = "0.8.5"
         val spotlessVersion = "3.25.0"
         val errorpronePlugin = "net.ltgt.gradle:gradle-errorprone-plugin:1.1.1"
     }
@@ -51,7 +51,7 @@ object Config {
     object CompileOnly {
         private val nopenVersion = "1.0.1"
 
-        val annotations = "org.jetbrains:annotations:17.0.0"
+        val annotations = "org.jetbrains:annotations:18.0.0"
         val noopen = "com.jakewharton.nopen:nopen-annotations:$nopenVersion"
         val noopenProne = "com.jakewharton.nopen:nopen-checker:$nopenVersion"
         val errorprone = "com.google.errorprone:error_prone_core:2.3.3"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/sh
+# From gist at https://gist.github.com/chadmaughan/5889802
+
+echo '[git hook] executing gradle spotlessCheck before commit'
+
+# run the spotlessCheck with the gradle wrapper
+./gradlew spotlessCheck --daemon
+
+# store the last exit code in a variable
+RESULT=$?
+
+# return the './gradlew spotlessCheck' exit code
+exit $RESULT

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -24,6 +24,9 @@
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
 
+# Prevent proguard from minifying exception type names
+-keep class * extends java.lang.Exception
+
 # Prevent R8 from leaving Data object members always null
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -23,7 +23,6 @@ final class AndroidOptionsInitializer {
     setDefaultInApp(context, options);
 
     // Integrations are registered in the same order. Watch outbox before adding NDK:
-    options.addIntegration(EnvelopeFileObserverIntegration.getCachedEnvelopeFileObserver());
     options.addIntegration(EnvelopeFileObserverIntegration.getOutboxFileObserver());
     options.addIntegration(new NdkIntegration());
     options.addIntegration(new AnrIntegration());

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -38,6 +38,13 @@ public final class AnrIntegration implements Integration {
                     "ANR triggered with message: %s",
                     error.getMessage());
 
+                // TODO: because it's 'handled=false' it's being assumed to be
+                // crashed=true (set further down) which is incorrect
+                // ANR detected from NDK is crashed=true but not here
+                // since the user can "keep waiting".
+                // The side effect of being 'crashed=true' is that
+                // the SDK will store it on disk on the calling thread and
+                // not attempt to send it at all (crash=true means it will crash)
                 Mechanism mechanism = new Mechanism();
                 mechanism.setType("ANR");
                 mechanism.setHandled(false);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -6,7 +6,7 @@ import io.sentry.core.IHub;
 import io.sentry.core.Integration;
 import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
-import io.sentry.core.exception.ExceptionMechanismThrowable;
+import io.sentry.core.exception.ExceptionMechanismException;
 import io.sentry.core.protocol.Mechanism;
 
 public final class AnrIntegration implements Integration {
@@ -48,8 +48,8 @@ public final class AnrIntegration implements Integration {
                 Mechanism mechanism = new Mechanism();
                 mechanism.setType("ANR");
                 mechanism.setHandled(false);
-                ExceptionMechanismThrowable throwable =
-                    new ExceptionMechanismThrowable(mechanism, error, Thread.currentThread());
+                ExceptionMechanismException throwable =
+                    new ExceptionMechanismException(mechanism, error, Thread.currentThread());
 
                 hub.captureException(throwable);
               },

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationNotResponding.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationNotResponding.java
@@ -13,12 +13,12 @@ import org.jetbrains.annotations.NotNull;
  * really the cause of the exception. Each "Caused by" is the stack trace of a running thread. Note
  * that the main thread always comes first.
  */
-final class ApplicationNotResponding extends Throwable {
+final class ApplicationNotResponding extends RuntimeException {
   private static final long serialVersionUID = 252541144579117016L;
 
   private Thread.State state;
 
-  public ApplicationNotResponding(@NotNull String message, @NotNull Thread thread) {
+  ApplicationNotResponding(@NotNull String message, @NotNull Thread thread) {
     super(message);
     thread = Objects.requireNonNull(thread, "Thread must be provided.");
     setStackTrace(thread.getStackTrace());

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
@@ -24,13 +24,12 @@ final class EnvelopeFileObserver extends FileObserver {
   @Override
   public void onEvent(int eventType, @Nullable String relativePath) {
     if (relativePath == null
-      // Protocol with sentry-native is a rename
-      // TODO: Check file extension matches once sentry-native starts renaming the file
-      // && eventType != FileObserver.
-      // event types: https://developer.android.com/reference/android/os/FileObserver.html
-      // TODO: Currently sentry-native simply writes so watch for close-write
-      || eventType != FileObserver.CLOSE_WRITE
-    ) {
+        // Protocol with sentry-native is a rename
+        // TODO: Check file extension matches once sentry-native starts renaming the file
+        // && eventType != FileObserver.
+        // event types: https://developer.android.com/reference/android/os/FileObserver.html
+        // TODO: Currently sentry-native simply writes so watch for close-write
+        || eventType != FileObserver.CLOSE_WRITE) {
       return;
     }
 
@@ -40,7 +39,6 @@ final class EnvelopeFileObserver extends FileObserver {
         eventType,
         this.rootPath,
         relativePath);
-
 
     envelopeSender.processEnvelopeFile(this.rootPath + File.separator + relativePath);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
@@ -23,7 +23,14 @@ final class EnvelopeFileObserver extends FileObserver {
 
   @Override
   public void onEvent(int eventType, @Nullable String relativePath) {
-    if (relativePath == null) {
+    if (relativePath == null
+      // Protocol with sentry-native is a rename
+      // TODO: Check file extension matches once sentry-native starts renaming the file
+      // && eventType != FileObserver.
+      // event types: https://developer.android.com/reference/android/os/FileObserver.html
+      // TODO: Currently sentry-native simply writes so watch for close-write
+      || eventType != FileObserver.CLOSE_WRITE
+    ) {
       return;
     }
 
@@ -34,7 +41,6 @@ final class EnvelopeFileObserver extends FileObserver {
         this.rootPath,
         relativePath);
 
-    // TODO: Only some event types should be pass through?
 
     envelopeSender.processEnvelopeFile(this.rootPath + File.separator + relativePath);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -7,7 +7,6 @@ import io.sentry.core.Integration;
 import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
 import java.io.Closeable;
-import java.io.File;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
@@ -45,10 +44,6 @@ abstract class EnvelopeFileObserverIntegration implements Integration, Closeable
     return new OutboxEnvelopeFileObserverIntegration();
   }
 
-  public static EnvelopeFileObserverIntegration getCachedEnvelopeFileObserver() {
-    return new JavaCachedEnvelopeFileObserverIntegration();
-  }
-
   @TestOnly
   abstract String getPath(SentryOptions options);
 
@@ -57,15 +52,6 @@ abstract class EnvelopeFileObserverIntegration implements Integration, Closeable
     @Override
     protected String getPath(final SentryOptions options) {
       return options.getOutboxPath();
-    }
-  }
-
-  private static final class JavaCachedEnvelopeFileObserverIntegration
-      extends EnvelopeFileObserverIntegration {
-    @Override
-    protected String getPath(final SentryOptions options) {
-      // TODO: Wherever we're caching events from the Java layer
-      return options.getCacheDirPath() + File.separator + "cached";
     }
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -19,7 +19,7 @@ final class ManifestMetadataReader {
   static final String ANR_REPORT_DEBUG = "io.sentry.anr.report-debug";
   static final String ANR_TIMEOUT_INTERVAL_MILLS = "io.sentry.anr.timeout-interval-mills";
   static final String AUTO_INIT = "io.sentry.auto-init";
-  static final String ENABLE_NDK = "io.sentry.ndk";
+  static final String ENABLE_NDK = "io.sentry.ndk.enable";
 
   static void applyMetadata(Context context, SentryAndroidOptions options) {
     if (context == null) throw new IllegalArgumentException("The application context is required.");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -39,15 +39,6 @@ class EnvelopeFileObserverIntegrationTest {
     }
 
     @Test
-    fun `when instance from getCachedEnvelopeFileObserver, options getCacheDirPath + cache dir is used`() {
-        val options = SentryOptions()
-        options.cacheDirPath = "some_dir"
-
-        val sut = EnvelopeFileObserverIntegration.getCachedEnvelopeFileObserver()
-        assertEquals(options.cacheDirPath + File.separator + "cached", sut.getPath(options))
-    }
-
-    @Test
     fun `when hub is closed, integrations should be closed`() {
         val integrationMock = mock<EnvelopeFileObserverIntegration>()
         val options = SentryOptions()

--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -54,14 +54,5 @@ JNIEXPORT void JNICALL Java_io_sentry_android_ndk_SentryNdk_initSentryNative(JNI
     sentry_options_set_debug(options, g_transport_options.debug);
     sentry_options_set_dsn(options, (*env)->GetStringUTFChars(env, dsn, 0));
     sentry_init(options);
-
-    sentry_value_t event = sentry_value_new_event();
-    sentry_value_set_by_key(event, "message",
-                            sentry_value_new_string("Hello World!"));
-
-    sentry_capture_event(event);
-
-    sentry_shutdown();
-
 }
 

--- a/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
@@ -6,7 +6,6 @@ import io.sentry.core.transport.HttpTransport;
 import io.sentry.core.transport.IBackOffIntervalStrategy;
 import io.sentry.core.transport.IConnectionConfigurator;
 import io.sentry.core.transport.ITransportGate;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 

--- a/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
@@ -1,7 +1,12 @@
 package io.sentry.core;
 
 import io.sentry.core.cache.IEventCache;
-import io.sentry.core.transport.*;
+import io.sentry.core.transport.AsyncConnection;
+import io.sentry.core.transport.HttpTransport;
+import io.sentry.core.transport.IBackOffIntervalStrategy;
+import io.sentry.core.transport.IConnectionConfigurator;
+import io.sentry.core.transport.ITransportGate;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 

--- a/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
+++ b/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
@@ -108,9 +108,7 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
 
       for (Map.Entry<String, Object> item : unknown.entrySet()) {
         if (item != null) {
-          unknownClone.put(
-              item.getKey(),
-              item.getValue()); // TODO: how do we clone an object that we dont know the shape of it
+          unknownClone.put(item.getKey(), item.getValue()); // shallow copy
         }
       }
 

--- a/sentry-core/src/main/java/io/sentry/core/EnvelopeSender.java
+++ b/sentry-core/src/main/java/io/sentry/core/EnvelopeSender.java
@@ -53,7 +53,7 @@ public final class EnvelopeSender implements IEnvelopeSender {
       }
       if (file != null && !cachedEvent.isResend()) {
         try {
-            file.delete();
+          file.delete();
         } catch (Exception e) {
           logger.log(SentryLevel.ERROR, "Failed to delete.", e);
         }
@@ -61,7 +61,8 @@ public final class EnvelopeSender implements IEnvelopeSender {
     }
   }
 
-  private void processEnvelope(SentryEnvelope envelope, CachedEvent cachedEvent) throws IOException {
+  private void processEnvelope(SentryEnvelope envelope, CachedEvent cachedEvent)
+      throws IOException {
     logger.log(SentryLevel.DEBUG, "Envelope for event Id: %s", envelope.getHeader().getEventId());
     int items = 0;
     for (SentryEnvelopeItem item : envelope.getItems()) {

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -36,6 +36,8 @@ public final class Hub implements IHub {
   }
 
   private Hub(@NotNull SentryOptions options, @Nullable StackItem rootStackItem) {
+    validateOptions(options);
+
     this.options = options;
     if (rootStackItem != null) {
       this.stack.push(rootStackItem);
@@ -51,8 +53,16 @@ public final class Hub implements IHub {
     }
   }
 
-  private static StackItem createRootStackItem(@NotNull SentryOptions options) {
+  private static void validateOptions(@NotNull SentryOptions options) {
     Objects.requireNonNull(options, "SentryOptions is required.");
+    if (options.getDsn() == null || options.getDsn().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Hub requires a DSN to be instantiated. Considering using the NoOpHub is no DSN is available.");
+    }
+  }
+
+  private static StackItem createRootStackItem(@NotNull SentryOptions options) {
+    validateOptions(options);
     Scope scope = new Scope(options.getMaxBreadcrumbs());
     ISentryClient client = new SentryClient(options);
     return new StackItem(client, scope);
@@ -287,7 +297,7 @@ public final class Hub implements IHub {
           "Instance is disabled and this 'popScope' call is a no-op.");
     } else {
       // Don't drop the root scope
-      synchronized (stack) { // TODO: is it necessary? we should never sync a concurrent object
+      synchronized (stack) {
         if (stack.size() != 1) {
           stack.pop();
         } else {

--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -41,6 +41,11 @@ public final class MainEventProcessor implements EventProcessor {
       event.setEnvironment(options.getEnvironment());
     }
 
+    if (event.getPlatform() == null) {
+      // this actually means JVM related.
+      event.setPlatform("java");
+    }
+
     Throwable throwable = event.getThrowable();
     if (throwable != null) {
       event.setExceptions(sentryExceptionFactory.getSentryExceptions(throwable));
@@ -55,7 +60,7 @@ public final class MainEventProcessor implements EventProcessor {
               && exception.getMechanism() != null
               // If mechanism is set to handled=false, this will crash the app.
               // Provide the thread-id if available to mark the thread-list with the crashed one.
-              && Boolean.FALSE.equals(exception.getMechanism().getHandled())) {
+              && Boolean.FALSE.equals(exception.getMechanism().isHandled())) {
             crashedThreadId = exception.getThreadId();
             break;
           }

--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
@@ -20,6 +20,7 @@ final class SendCachedEventFireAndForgetIntegration implements Integration {
     File outbox = new File(cachedDir);
 
     try {
+      // TODO: Not running on a background thread?!
       Executors.callable(
               () -> {
                 try {

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
 public final class SentryClient implements ISentryClient {
   static final String SENTRY_PROTOCOL_VERSION = "7";
 
-  private boolean isEnabled;
+  private boolean enabled;
 
   private final SentryOptions options;
   private final Connection connection;
@@ -27,7 +27,7 @@ public final class SentryClient implements ISentryClient {
 
   @Override
   public boolean isEnabled() {
-    return isEnabled;
+    return enabled;
   }
 
   SentryClient(SentryOptions options) {
@@ -36,7 +36,7 @@ public final class SentryClient implements ISentryClient {
 
   public SentryClient(SentryOptions options, @Nullable Connection connection) {
     this.options = options;
-    this.isEnabled = true;
+    this.enabled = true;
     if (connection == null) {
 
       // TODO this is obviously provisional and should be constructed based on the config in options
@@ -167,7 +167,7 @@ public final class SentryClient implements ISentryClient {
           "Failed to close the connection to the Sentry Server.",
           e);
     }
-    isEnabled = false;
+    enabled = false;
   }
 
   @Override

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -113,7 +113,7 @@ public final class SentryClient implements ISentryClient {
     }
 
     try {
-      connection.send(event);
+      connection.send(event, hint);
     } catch (IOException e) {
       logIfNotNull(
           options.getLogger(),

--- a/sentry-core/src/main/java/io/sentry/core/SentryExceptionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryExceptionFactory.java
@@ -1,6 +1,6 @@
 package io.sentry.core;
 
-import io.sentry.core.exception.ExceptionMechanismThrowable;
+import io.sentry.core.exception.ExceptionMechanismException;
 import io.sentry.core.protocol.Mechanism;
 import io.sentry.core.protocol.SentryException;
 import io.sentry.core.protocol.SentryStackTrace;
@@ -106,10 +106,10 @@ final class SentryExceptionFactory {
 
     // Stack the exceptions to send them in the reverse order
     while (currentThrowable != null && circularityDetector.add(currentThrowable)) {
-      if (currentThrowable instanceof ExceptionMechanismThrowable) {
+      if (currentThrowable instanceof ExceptionMechanismException) {
         // this is for ANR I believe
-        ExceptionMechanismThrowable exceptionMechanismThrowable =
-            (ExceptionMechanismThrowable) currentThrowable;
+        ExceptionMechanismException exceptionMechanismThrowable =
+            (ExceptionMechanismException) currentThrowable;
         exceptionMechanism = exceptionMechanismThrowable.getExceptionMechanism();
         currentThrowable = exceptionMechanismThrowable.getThrowable();
         thread = exceptionMechanismThrowable.getThread();

--- a/sentry-core/src/main/java/io/sentry/core/SentryStackTraceFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryStackTraceFactory.java
@@ -2,6 +2,7 @@ package io.sentry.core;
 
 import io.sentry.core.protocol.SentryStackFrame;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,6 +46,7 @@ final class SentryStackTraceFactory {
         }
       }
     }
+    Collections.reverse(sentryStackFrames);
 
     return sentryStackFrames;
   }

--- a/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
@@ -32,9 +32,9 @@ final class SentryThreadFactory {
     Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
     List<SentryThread> result = new ArrayList<>();
 
+    Thread currentThread = Thread.currentThread();
     for (Map.Entry<Thread, StackTraceElement[]> item : threads.entrySet()) {
-      result.add(
-          getSentryThread(crashedThreadId, Thread.currentThread(), item.getValue(), item.getKey()));
+      result.add(getSentryThread(crashedThreadId, currentThread, item.getValue(), item.getKey()));
     }
 
     return result;
@@ -55,7 +55,7 @@ final class SentryThreadFactory {
     if (crashedThreadId != null) {
       sentryThread.setCrashed(crashedThreadId == thread.getId());
     }
-    sentryThread.setCurrent(thread == currentThread);
+    sentryThread.setErrored(thread == currentThread);
 
     List<SentryStackFrame> frames = sentryStackTraceFactory.getStackFrames(stackFramesElements);
 

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -2,7 +2,7 @@ package io.sentry.core;
 
 import static io.sentry.core.ILogger.logIfNotNull;
 
-import io.sentry.core.exception.ExceptionMechanismThrowable;
+import io.sentry.core.exception.ExceptionMechanismException;
 import io.sentry.core.protocol.Mechanism;
 import io.sentry.core.util.Objects;
 import java.io.Closeable;
@@ -21,7 +21,7 @@ public final class UncaughtExceptionHandlerIntegration
   private IHub hub;
   private SentryOptions options;
 
-  private boolean isRegistered = false;
+  private boolean registered = false;
   private UncaughtExceptionHandler threadAdapter;
 
   UncaughtExceptionHandlerIntegration() {
@@ -34,14 +34,14 @@ public final class UncaughtExceptionHandlerIntegration
 
   @Override
   public void register(IHub hub, SentryOptions options) {
-    if (isRegistered) {
+    if (registered) {
       logIfNotNull(
           options.getLogger(),
           SentryLevel.ERROR,
           "Attempt to register a UncaughtExceptionHandlerIntegration twice. ");
       return;
     }
-    isRegistered = true;
+    registered = true;
 
     this.hub = hub;
     this.options = options;
@@ -82,7 +82,7 @@ public final class UncaughtExceptionHandlerIntegration
     Mechanism mechanism = new Mechanism();
     mechanism.setHandled(false);
     mechanism.setType("UncaughtExceptionHandler");
-    return new ExceptionMechanismThrowable(mechanism, thrown, thread);
+    return new ExceptionMechanismException(mechanism, thrown, thread);
   }
 
   @Override

--- a/sentry-core/src/main/java/io/sentry/core/exception/ExceptionMechanismException.java
+++ b/sentry-core/src/main/java/io/sentry/core/exception/ExceptionMechanismException.java
@@ -1,0 +1,42 @@
+package io.sentry.core.exception;
+
+import io.sentry.core.protocol.Mechanism;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A throwable decorator that holds an {@link io.sentry.core.protocol.Mechanism} related to the
+ * decorated {@link Throwable}.
+ */
+public final class ExceptionMechanismException extends RuntimeException {
+  private static final long serialVersionUID = 142345454265713915L;
+
+  private final Mechanism exceptionMechanism;
+  private final Throwable throwable;
+  private final Thread thread;
+
+  /**
+   * A {@link Throwable} that decorates another with a Sentry {@link Mechanism}.
+   *
+   * @param mechanism The {@link Mechanism}.
+   * @param throwable The {@link java.lang.Throwable}.
+   * @param thread The {@link java.lang.Thread}.
+   */
+  public ExceptionMechanismException(
+      @Nullable Mechanism mechanism, @Nullable Throwable throwable, @Nullable Thread thread) {
+    this.exceptionMechanism = mechanism;
+    this.throwable = throwable;
+    this.thread = thread;
+  }
+
+  public Mechanism getExceptionMechanism() {
+    return exceptionMechanism;
+  }
+
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  public Thread getThread() {
+    return thread;
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Gpu.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Gpu.java
@@ -67,7 +67,7 @@ public final class Gpu implements IUnknownPropertiesConsumer {
     this.apiType = apiType;
   }
 
-  public Boolean getMultiThreadedRendering() {
+  public Boolean isMultiThreadedRendering() {
     return multiThreadedRendering;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Mechanism.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Mechanism.java
@@ -48,7 +48,7 @@ public final class Mechanism implements IUnknownPropertiesConsumer {
     this.helpLink = helpLink;
   }
 
-  public Boolean getHandled() {
+  public Boolean isHandled() {
     return handled;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackFrame.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackFrame.java
@@ -1,5 +1,6 @@
 package io.sentry.core.protocol;
 
+import com.google.gson.annotations.SerializedName;
 import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.List;
 import java.util.Map;
@@ -18,8 +19,13 @@ public final class SentryStackFrame implements IUnknownPropertiesConsumer {
   private String absPath;
   private String contextLine;
   private Boolean inApp;
-  private String _package; // TODO: _package as its a reserverd word
-  private Boolean _native; // TODO: _native as its a reserverd word
+
+  @SerializedName(value = "package")
+  private String _package;
+
+  @SerializedName(value = "native")
+  private Boolean _native;
+
   private String platform;
   private Long imageAddr;
   private Long symbolAddr;
@@ -118,7 +124,7 @@ public final class SentryStackFrame implements IUnknownPropertiesConsumer {
     this.contextLine = contextLine;
   }
 
-  public Boolean getInApp() {
+  public Boolean isInApp() {
     return inApp;
   }
 
@@ -126,11 +132,11 @@ public final class SentryStackFrame implements IUnknownPropertiesConsumer {
     this.inApp = inApp;
   }
 
-  public String get_package() {
+  public String getPackage() {
     return _package;
   }
 
-  public void set_package(String _package) {
+  public void setPackage(String _package) {
     this._package = _package;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/protocol/SentryThread.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SentryThread.java
@@ -11,8 +11,9 @@ public final class SentryThread implements IUnknownPropertiesConsumer {
   private String state;
   private Boolean crashed;
   private Boolean current;
-  private Boolean isDaemon;
+  private Boolean daemon;
   private SentryStackTrace stacktrace;
+  private Boolean errored;
 
   @SuppressWarnings("unused")
   private Map<String, Object> unknown;
@@ -58,7 +59,7 @@ public final class SentryThread implements IUnknownPropertiesConsumer {
    *
    * @return whether it was the crashed thread.
    */
-  public Boolean getCrashed() {
+  public Boolean isCrashed() {
     return crashed;
   }
 
@@ -76,7 +77,7 @@ public final class SentryThread implements IUnknownPropertiesConsumer {
    *
    * @return whether the thread was in the foreground.
    */
-  public Boolean getCurrent() {
+  public Boolean isCurrent() {
     return current;
   }
 
@@ -130,8 +131,8 @@ public final class SentryThread implements IUnknownPropertiesConsumer {
    *
    * @return if this is a daemon thread.
    */
-  public Boolean getDaemon() {
-    return isDaemon;
+  public Boolean isDaemon() {
+    return daemon;
   }
 
   /**
@@ -140,7 +141,7 @@ public final class SentryThread implements IUnknownPropertiesConsumer {
    * @param daemon true if the thread is daemon thread. Otherwise false.
    */
   public void setDaemon(Boolean daemon) {
-    isDaemon = daemon;
+    this.daemon = daemon;
   }
 
   /**
@@ -164,5 +165,13 @@ public final class SentryThread implements IUnknownPropertiesConsumer {
   @Override
   public void acceptUnknownProperties(Map<String, Object> unknown) {
     this.unknown = unknown;
+  }
+
+  public Boolean isErrored() {
+    return errored;
+  }
+
+  public void setErrored(Boolean errored) {
+    this.errored = errored;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
 import org.jetbrains.annotations.*;
 
 /** A connection to Sentry that sends the events asynchronously. */
@@ -90,7 +89,7 @@ public final class AsyncConnection implements Closeable, Connection {
   public void send(SentryEvent event, Object hint) throws IOException {
     CachedEvent cachedEvent = null;
     if (hint instanceof CachedEvent) {
-      cachedEvent = (CachedEvent)hint;
+      cachedEvent = (CachedEvent) hint;
     }
     EventSender sender = new EventSender(event, cachedEvent);
 
@@ -165,7 +164,8 @@ public final class AsyncConnection implements Closeable, Connection {
             if (cachedEvent == null && !storeBeforeSend) {
               eventCache.store(event);
             }
-            // TODO: Here we could inspect result and decide whether to mark eventCache.setResend(true)
+            // TODO: Here we could inspect result and decide whether to mark
+            // eventCache.setResend(true)
             suggestedRetryDelay = result.getRetryMillis();
 
             String message =

--- a/sentry-core/src/main/java/io/sentry/core/transport/Connection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/Connection.java
@@ -1,12 +1,12 @@
 package io.sentry.core.transport;
 
 import io.sentry.core.SentryEvent;
-import org.jetbrains.annotations.Nullable;
-
 import java.io.IOException;
+import org.jetbrains.annotations.Nullable;
 
 public interface Connection {
   void send(SentryEvent event, @Nullable Object hint) throws IOException;
+
   default void send(SentryEvent event) throws IOException {
     send(event, null);
   }

--- a/sentry-core/src/main/java/io/sentry/core/transport/Connection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/Connection.java
@@ -1,10 +1,15 @@
 package io.sentry.core.transport;
 
 import io.sentry.core.SentryEvent;
+import org.jetbrains.annotations.Nullable;
+
 import java.io.IOException;
 
 public interface Connection {
-  void send(SentryEvent event) throws IOException;
+  void send(SentryEvent event, @Nullable Object hint) throws IOException;
+  default void send(SentryEvent event) throws IOException {
+    send(event, null);
+  }
 
   void close() throws IOException;
 }

--- a/sentry-core/src/main/java/io/sentry/core/transport/CrashedEventStore.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/CrashedEventStore.java
@@ -1,6 +1,6 @@
 package io.sentry.core.transport;
 
-import io.sentry.core.SentryEvent;
+import io.sentry.core.*;
 import io.sentry.core.cache.IEventCache;
 import io.sentry.core.protocol.SentryThread;
 import io.sentry.core.util.Objects;
@@ -20,18 +20,20 @@ public final class CrashedEventStore implements Connection {
   }
 
   @Override
-  public void send(@NotNull SentryEvent event) throws IOException {
-    List<SentryThread> threads = event.getThreads();
-    if (threads != null) {
-      for (SentryThread thread : threads) {
-        if (Boolean.TRUE.equals(thread.getCrashed())) {
-          eventCache.store(event);
-          return;
+  public void send(@NotNull SentryEvent event, Object hint) throws IOException {
+    if (!(hint instanceof CachedEvent)) {
+      List<SentryThread> threads = event.getThreads();
+      if (threads != null) {
+        for (SentryThread thread : threads) {
+          if (Boolean.TRUE.equals(thread.getCrashed())) {
+            eventCache.store(event);
+            return;
+          }
         }
       }
     }
 
-    inner.send(event);
+    inner.send(event, hint);
   }
 
   @Override

--- a/sentry-core/src/main/java/io/sentry/core/transport/CrashedEventStore.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/CrashedEventStore.java
@@ -25,7 +25,7 @@ public final class CrashedEventStore implements Connection {
       List<SentryThread> threads = event.getThreads();
       if (threads != null) {
         for (SentryThread thread : threads) {
-          if (Boolean.TRUE.equals(thread.getCrashed())) {
+          if (Boolean.TRUE.equals(thread.isCrashed())) {
             eventCache.store(event);
             return;
           }

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class HubTest {
@@ -32,6 +33,12 @@ class HubTest {
     @AfterTest
     fun shutdown() {
         Files.delete(file.toPath())
+    }
+
+    @Test
+    fun `when no dsn available, ctor throws illegal arg`() {
+        val ex = assertFailsWith<IllegalArgumentException> { Hub(SentryOptions()) }
+        assertEquals("Hub requires a DSN to be instantiated. Considering using the NoOpHub is no DSN is available.", ex.message)
     }
 
     @Test

--- a/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
@@ -27,7 +27,7 @@ class MainEventProcessorTest {
         sut.process(event, null)
 
         assertSame(crashedThread.id, event.exceptions.first().threadId)
-        assertTrue(event.threads.first { t -> t.id == crashedThread.id }.crashed)
-        assertFalse(event.exceptions.first().mechanism.handled)
+        assertTrue(event.threads.first { t -> t.id == crashedThread.id }.isCrashed)
+        assertFalse(event.exceptions.first().mechanism.isHandled)
     }
 }

--- a/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.core
 
-import io.sentry.core.exception.ExceptionMechanismThrowable
+import io.sentry.core.exception.ExceptionMechanismException
 import io.sentry.core.protocol.Mechanism
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,15 +34,15 @@ class SentryExceptionFactoryTest {
     fun `when getSentryExceptions is called passing a ExceptionMechanism, it should set its fields`() {
         val mechanism = Mechanism()
         mechanism.type = "anr"
-        mechanism.handled = false
+        mechanism.isHandled = false
 
         val error = Exception("Exception")
 
-        val throwable = ExceptionMechanismThrowable(mechanism, error, null)
+        val throwable = ExceptionMechanismException(mechanism, error, null)
 
         val sentryExceptions = sut.getSentryExceptions(throwable)
         assertEquals("anr", sentryExceptions[0].mechanism.type)
-        assertEquals(false, sentryExceptions[0].mechanism.handled)
+        assertEquals(false, sentryExceptions[0].mechanism.isHandled)
     }
 
     @Test

--- a/sentry-core/src/test/java/io/sentry/core/SentryStackTraceFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryStackTraceFactoryTest.kt
@@ -55,7 +55,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(listOf("io.sentry"), null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertFalse(sentryElements.first().inApp)
+        assertFalse(sentryElements.first().isInApp)
     }
 
     @Test
@@ -65,7 +65,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(listOf("io.sentry"), null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().inApp)
+        assertTrue(sentryElements.first().isInApp)
     }
 
     @Test
@@ -75,7 +75,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(null, null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().inApp)
+        assertTrue(sentryElements.first().isInApp)
     }
     //endregion
 
@@ -87,7 +87,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(null, listOf("io.sentry"))
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().inApp)
+        assertTrue(sentryElements.first().isInApp)
     }
 
     @Test
@@ -97,7 +97,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(null, listOf("io.sentry"))
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().inApp)
+        assertTrue(sentryElements.first().isInApp)
     }
 
     @Test
@@ -107,7 +107,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(null, null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().inApp)
+        assertTrue(sentryElements.first().isInApp)
     }
     //endregion
 
@@ -118,7 +118,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(listOf("io.sentry"), listOf("io.sentry"))
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().inApp)
+        assertTrue(sentryElements.first().isInApp)
     }
 
     private fun generateStackTrace(className: String?) =

--- a/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
@@ -19,14 +19,14 @@ class SentryThreadFactoryTest {
         val threads = sut.currentThreadsForCrash
         val currentThread = Thread.currentThread()
         val currentSentryThread = threads.first { it.id == currentThread.id }
-        assertTrue(currentSentryThread.crashed)
-        assertTrue(currentSentryThread.current)
-        assertTrue(threads.filter { it.id != currentThread.id }.all { !it.crashed && !it.current })
+        assertTrue(currentSentryThread.isCrashed)
+        assertTrue(currentSentryThread.isErrored)
+        assertTrue(threads.filter { it.id != currentThread.id }.all { !it.isCrashed && !it.isErrored })
     }
 
     @Test
     fun `when currentThreads is called, no thread is marked either crashed or not`() =
-        assertTrue(sut.currentThreads.all { it.crashed == null })
+        assertTrue(sut.currentThreads.all { it.isCrashed == null })
 
     @Test
     fun `when currentThreads is called, thread state is captured`() =

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -6,7 +6,7 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import io.sentry.core.exception.ExceptionMechanismThrowable
+import io.sentry.core.exception.ExceptionMechanismException
 import io.sentry.core.protocol.SentryId
 import java.io.File
 import java.nio.file.Files
@@ -72,10 +72,10 @@ class UncaughtExceptionHandlerIntegrationTest {
         val throwableMock = mock<Throwable>()
         val hubMock = mock<IHub>()
         whenever(hubMock.captureException(any())).thenAnswer { invocation ->
-            val e = (invocation.arguments[1] as ExceptionMechanismThrowable)
+            val e = (invocation.arguments[1] as ExceptionMechanismException)
             assertNotNull(e)
             assertNotNull(e.exceptionMechanism)
-            assertTrue(e.exceptionMechanism.handled)
+            assertTrue(e.exceptionMechanism.isHandled)
             SentryId.EMPTY_ID
         }
         val options = SentryOptions()

--- a/sentry-core/src/test/java/io/sentry/core/transport/CrashedEventStoreTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/CrashedEventStoreTest.kt
@@ -23,7 +23,7 @@ class CrashedEventStoreTest {
     fun `when event includes a crashed thread, event is persisted`() {
         val sut = fixture.getSut()
         val actual = SentryEvent().apply {
-            threads = listOf(SentryThread().apply { crashed = true })
+            threads = listOf(SentryThread().apply { isCrashed = true })
         }
         sut.send(actual)
         verify(fixture.eventCache).store(actual)
@@ -34,7 +34,7 @@ class CrashedEventStoreTest {
     fun `when event doesn't include a crashed thread, event is passed to inner connection`() {
         val sut = fixture.getSut()
         val actual = SentryEvent().apply {
-            threads = listOf(SentryThread().apply { crashed = false })
+            threads = listOf(SentryThread().apply { isCrashed = false })
         }
         sut.send(actual)
         verify(fixture.connection).send(actual)

--- a/sentry-sample/build.gradle.kts
+++ b/sentry-sample/build.gradle.kts
@@ -60,6 +60,7 @@ android {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             signingConfig = signingConfigs.getByName("debug") // to be able to run release mode
+            isShrinkResources = true
         }
     }
 

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
     <meta-data android:name="io.sentry.debug" android:value="true" />
 
     <!-- Raise a ANR event if UI thread blocked for over 2 seconds -->
-    <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="2000" />
+    <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="4000" />
 
     <!-- Raise ANR events even if the debugger is attached -->
     <meta-data android:name="io.sentry.anr.report-debug" android:value="true" />

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -34,12 +34,15 @@
     <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="4000" />
 
     <!-- Raise ANR events even if the debugger is attached -->
-    <meta-data android:name="io.sentry.anr.report-debug" android:value="true" />
+<!--    <meta-data android:name="io.sentry.anr.report-debug" android:value="true" />-->
+
+<!--    how to disable ANR-->
+<!--    <meta-data android:name="io.sentry.anr.enable" android:value="false" />-->
 
 <!--    how to disable the auto-init-->
 <!--    <meta-data android:name="io.sentry.auto-init" android:value="false" />-->
 
 <!--    how to disable the NDK-->
-<!--    <meta-data android:name="io.sentry.ndk" android:value="false" />-->
+<!--    <meta-data android:name="io.sentry.ndk.enable" android:value="false" />-->
   </application>
 </manifest>

--- a/sentry-sample/src/main/cpp/native-sample.cpp
+++ b/sentry-sample/src/main/cpp/native-sample.cpp
@@ -1,14 +1,14 @@
 #include <jni.h>
-#include <signal.h>
 #include <android/log.h>
 
 #define TAG "sentry-android-sample"
 
 extern "C" {
 
-JNIEXPORT void JNICALL Java_io_sentry_sample_NativeSample_crash(JNIEnv *env) {
-    __android_log_print(ANDROID_LOG_WARN, TAG, "About to raise SIGSEGV.");
-    raise(SIGSEGV);
+JNIEXPORT void JNICALL Java_io_sentry_sample_NativeSample_crash(JNIEnv *env, jclass cls) {
+    __android_log_print(ANDROID_LOG_WARN, TAG, "About to crash.");
+    char *ptr = 0;
+    *ptr += 1;
 }
 
 }

--- a/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
@@ -33,7 +33,8 @@ public class MainActivity extends AppCompatActivity {
     findViewById(R.id.capture_exception)
         .setOnClickListener(
             view -> {
-              Sentry.captureException(new Exception("Some exception."));
+              Sentry.captureException(
+                  new Exception(new Exception(new Exception("Some exception."))));
             });
 
     findViewById(R.id.breadcrumb)

--- a/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
@@ -67,7 +67,7 @@ public class MainActivity extends AppCompatActivity {
             view -> {
               // Try cause ANR (triggers after 1 second as configured via meta-data)
               try {
-                Thread.sleep(2000);
+                Thread.sleep(5000);
               } catch (InterruptedException e) {
                 return;
               }


### PR DESCRIPTION
We have one big gap: 
Currently envelopes from `sentry-native` are only picked up via the FileObserver integration. Which means we don't pick up previous crashes. The code working on cached events from Java vs envelopes from C++ have a lot of overlap and can be easily refactored to be share some logic. Same with having the trigger (FireAndFogetOnStart vs FileObserver) take as a strategy whatever it action to perform on the located files (unwrap envelopes or send events).

I'm opening this PR just to share the current state in case you want to look at it tomorrow. 