### PR TITLE
setting correct names to package and native attributes (stack frames)

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackFrame.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/SentryStackFrame.java
@@ -1,5 +1,6 @@
 package io.sentry.core.protocol;
 
+import com.google.gson.annotations.SerializedName;
 import io.sentry.core.IUnknownPropertiesConsumer;
 import java.util.List;
 import java.util.Map;
@@ -18,8 +19,13 @@ public final class SentryStackFrame implements IUnknownPropertiesConsumer {
   private String absPath;
   private String contextLine;
   private Boolean inApp;
-  private String _package; // TODO: _package as its a reserverd word
-  private Boolean _native; // TODO: _native as its a reserverd word
+
+  @SerializedName(value = "package")
+  private String _package;
+
+  @SerializedName(value = "native")
+  private Boolean _native;
+
   private String platform;
   private Long imageAddr;
   private Long symbolAddr;
@@ -126,11 +132,11 @@ public final class SentryStackFrame implements IUnknownPropertiesConsumer {
     this.inApp = inApp;
   }
 
-  public String get_package() {
+  public String getPackage() {
     return _package;
   }
 
-  public void set_package(String _package) {
+  public void setPackage(String _package) {
     this._package = _package;
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
setting correct names to package and native attributes (stack frames)


## :bulb: Motivation and Context
package and native are reserved words in java, but we need them like this when serialized/deserialized.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
getters and setters have the correct name, I will write an adapter later on, but let's fix it like this for now because it won't be a breaking change.