### PR TITLE
feat: publish to bintray

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,13 @@
 import com.diffplug.spotless.LineEnding
+import com.jfrog.bintray.gradle.BintrayExtension
+import com.jfrog.bintray.gradle.tasks.BintrayPublishTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     `java-library`
     id("com.diffplug.gradle.spotless") version Config.QualityPlugins.spotlessVersion apply true
+    id(Config.PublishPlugins.bintrayPlugin) version Config.PublishPlugins.bintrayVersion apply true
     jacoco
 }
 
@@ -34,6 +37,7 @@ allprojects {
     }
     group = "io.sentry"
     version = "2.0.0-SNAPSHOT"
+    description = "SDK for sentry.io"
     tasks {
         withType<Test> {
             testLogging.showStandardStreams = true

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -7,6 +7,11 @@ object Config {
         val kotlinGradlePlugin = "gradle-plugin"
     }
 
+    object PublishPlugins {
+        val bintrayPlugin = "com.jfrog.bintray"
+        val bintrayVersion = "1.8.4"
+    }
+
     object Android {
         private val sdkVersion = 29
 

--- a/sentry-sample/build.gradle.kts
+++ b/sentry-sample/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion
 plugins {
     id("com.android.application")
     kotlin("android")
-//    id("io.sentry.android.gradle") how to add sentry gradle plugin
+    id(Config.PublishPlugins.bintrayPlugin)
 }
 
 android {


### PR DESCRIPTION
While doing this I found we have to publish snapshot builds to artifactory instead.

The goal of this PR is to be able to publish packages via the main gradle file which will publish jar for sentry-core and arr for the Android libraries. It'll also ignore the sample project.