### PR TITLE
ref: revert type assignment

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEvent.java
@@ -85,7 +85,7 @@ final class SendCachedEvent {
         continue;
       }
 
-      Retryable hint = new SendCachedEventHint();
+      SendCachedEventHint hint = new SendCachedEventHint();
       try (Reader reader =
           new BufferedReader(new InputStreamReader(new FileInputStream(file), UTF_8))) {
         SentryEvent event = serializer.deserializeEvent(reader);

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -119,7 +119,7 @@ public final class UncaughtExceptionHandlerIntegration
       try {
         latch.await(timeoutMills, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
-        logIfNotNull(logger, ERROR, "Exception while flushing UncaughtExceptionHint", e);
+        logIfNotNull(logger, ERROR, "Exception while awaiting for flush in UncaughtExceptionHint", e);
       }
     }
 


### PR DESCRIPTION
I'd like to revert this with the following reasoning.

Hing is `Object`. So if simply using the base type on the right hand side of the assignment to make the compiler happy, we could do:

`Object hint = new SendCachedEventHint()`;
I'm sure we agree not to do this since it doesn't express the intent here. I'm instantiating `SendCachedEventHint` but can it be replaced by any `Object`?

This isnt' the same with `var` since in this case it would be, I don't care what the compiler infers. I see you're instantiating `SendCachedEventHint` and that means that's important and can't be overlooked.

`SendCachedEventHint` implements two interfaces and so far (up for discussion to change if there's a better way) a `hint is any Object` where the SDK support some well-known types (so far the 3 interfaces `Cached`, `Retryable` and `Flushable` so that we can support different use-cases.

My changing `SendCachedEventHint hint = new SendCachedEventHint()` to `Retryable hint = new SendCachedEventHint()` the intent of supporting exactly `SendCachedEventHint` or a type that implement all those interfaces, is gone.

What I'm looking for is:

`T hint = new ... where T : Retryable, Cached` and the closest to that in Java is:
`SendCachedEventHint hint = new SendCachedEventHint()`