### PR TITLE
feat: Unknown frames are not in app

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryStackTraceFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryStackTraceFactory.java
@@ -4,7 +4,7 @@ import io.sentry.core.protocol.SentryStackFrame;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.*;
 
 /** class responsible for converting Java StackTraceElements to SentryStackFrames */
 final class SentryStackTraceFactory {
@@ -51,7 +51,8 @@ final class SentryStackTraceFactory {
     return sentryStackFrames;
   }
 
-  private boolean isInApp(String className) {
+  @TestOnly
+  boolean isInApp(String className) {
     if (className == null || className.isEmpty()) {
       return true;
     }
@@ -70,6 +71,6 @@ final class SentryStackTraceFactory {
         }
       }
     }
-    return true;
+    return false;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryStackTraceFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryStackTraceFactory.java
@@ -4,7 +4,8 @@ import io.sentry.core.protocol.SentryStackFrame;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.jetbrains.annotations.*;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 /** class responsible for converting Java StackTraceElements to SentryStackFrames */
 final class SentryStackTraceFactory {

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -119,7 +119,8 @@ public final class UncaughtExceptionHandlerIntegration
       try {
         latch.await(timeoutMills, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
-        logIfNotNull(logger, ERROR, "Exception while awaiting for flush in UncaughtExceptionHint", e);
+        logIfNotNull(
+            logger, ERROR, "Exception while awaiting for flush in UncaughtExceptionHint", e);
       }
     }
 

--- a/sentry-core/src/test/java/io/sentry/core/SentryStackTraceFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryStackTraceFactoryTest.kt
@@ -59,13 +59,13 @@ class SentryStackTraceFactoryTest {
     }
 
     @Test
-    fun `when getStackFrames is called passing a valid inAppExcludes, inApp should be true if prefix doesnt matches it`() {
+    fun `when getStackFrames is called passing a valid inAppExcludes, inApp should be false if prefix doesnt matches it`() {
         val element = generateStackTrace("io.myapp.MyActivity")
         val elements = arrayOf(element)
         val sentryStackTraceFactory = SentryStackTraceFactory(listOf("io.sentry"), null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().isInApp)
+        assertFalse(sentryElements.first().isInApp)
     }
 
     @Test
@@ -75,7 +75,7 @@ class SentryStackTraceFactoryTest {
         val sentryStackTraceFactory = SentryStackTraceFactory(null, null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().isInApp)
+        assertFalse(sentryElements.first().isInApp)
     }
     //endregion
 
@@ -91,23 +91,23 @@ class SentryStackTraceFactoryTest {
     }
 
     @Test
-    fun `when getStackFrames is called passing a valid inAppIncludes, inApp should be true if prefix doesnt matches it`() {
+    fun `when getStackFrames is called passing a valid inAppIncludes, inApp should be false if prefix doesnt matches it`() {
         val element = generateStackTrace("io.myapp.MyActivity")
         val elements = arrayOf(element)
         val sentryStackTraceFactory = SentryStackTraceFactory(null, listOf("io.sentry"))
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().isInApp)
+        assertFalse(sentryElements.first().isInApp)
     }
 
     @Test
-    fun `when getStackFrames is called passing an invalid inAppIncludes, inApp should be true`() {
+    fun `when getStackFrames is called passing an invalid inAppIncludes, inApp should be false`() {
         val element = generateStackTrace("io.sentry.MyActivity")
         val elements = arrayOf(element)
         val sentryStackTraceFactory = SentryStackTraceFactory(null, null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertTrue(sentryElements.first().isInApp)
+        assertFalse(sentryElements.first().isInApp)
     }
     //endregion
 
@@ -119,6 +119,21 @@ class SentryStackTraceFactoryTest {
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
         assertTrue(sentryElements.first().isInApp)
+    }
+
+    @Test
+    fun `when class is defined in the app, inApp is true`() {
+        val sentryStackTraceFactory = SentryStackTraceFactory(listOf("io.sentry.not"), listOf("io.sentry.inApp"))
+        assertTrue(sentryStackTraceFactory.isInApp("io.sentry.inApp.ClassName"))
+        assertTrue(sentryStackTraceFactory.isInApp("io.sentry.inApp.somePackage.ClassName"))
+        assertFalse(sentryStackTraceFactory.isInApp("io.sentry.not.ClassName"))
+        assertFalse(sentryStackTraceFactory.isInApp("io.sentry.not.somePackage.ClassName"))
+    }
+
+    @Test
+    fun `when class is not in the list, is not inApp`() {
+        val sentryStackTraceFactory = SentryStackTraceFactory(listOf(), listOf("io.sentry"))
+        assertFalse(sentryStackTraceFactory.isInApp("com.getsentry"))
     }
 
     private fun generateStackTrace(className: String?) =


### PR DESCRIPTION
Since we add the app's namespace as `inAppInclude`, I propose default all frames as InApp=false.

Sentry should anyway show the whole stacktrace if *all frames* are inApp=false so if we somehow missed it, it would show the whole thing.
The default should be good enough as in only showing the app's stack frames and hiding everything else. If no app frames are included, everything is shown.