### PR TITLE
fix: inapp

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -241,6 +241,9 @@ public class SentryOptions {
     inAppExcludes.add("oracle.");
     inAppExcludes.add("org.jetbrains.");
 
+    inAppIncludes =
+        new ArrayList<>(); // make the list available so processor below can take the reference
+
     eventProcessors.add(new MainEventProcessor(this));
 
     // Start off sending any cached event.


### PR DESCRIPTION
No frame was marked as inApp because inAppInclude list was null and passed as an argument to the factory before the Android package could add (first the instance of the list) the inApp frames

![image](https://user-images.githubusercontent.com/1633368/68695348-dd7d9300-0548-11ea-8bda-688427c7a71f.png)
