### PR TITLE
fix proguard

### DIFF
--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -12,9 +12,10 @@
 #-keep class com.google.gson.stream.** { *; }
 
 # Application classes that will be serialized/deserialized over Gson
--keep class io.sentry.core.** { <fields>; }
--keep class io.sentry.core.protocol.** { <fields>; }
+-keep class io.sentry.core.** { *; }
+-keep class io.sentry.core.protocol.** { *; }
 -keepclassmembers enum * { *; }
+-keep class io.sentry.android.core.** { *; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)

--- a/sentry-android-ndk/proguard-rules.pro
+++ b/sentry-android-ndk/proguard-rules.pro
@@ -1,10 +1,16 @@
 ##---------------Begin: proguard configuration for NDK  ----------
 
--keep class io.sentry.ndk.** { <fields>; }
+-keep class io.sentry.android.ndk.** { *; }
 
 # For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
 -keepclasseswithmembernames,includedescriptorclasses class * {
     native <methods>;
 }
+
+# if issues with proguard, disable it
+#-dontshrink
+#-dontoptimize
+#-dontobfuscate
+#-dontpreverify
 
 ##---------------End: proguard configuration for NDK  ----------


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
added more exceptions to proguard


## :bulb: Motivation and Context
NDK cant be init. on release mode


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
move all classes to protocol package, so I dont need to do:
-keep class io.sentry.core.** { *; }
-keep class io.sentry.core.protocol.** { *; }

but only:
-keep class io.sentry.core.protocol.** { *; }