### PR TITLE
listing assets file on the wrong dir

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -792,7 +792,7 @@ public final class DefaultAndroidEventProcessor implements EventProcessor {
     InputStream is = null;
     try {
       AssetManager assets = context.getAssets();
-      String[] files = assets.list("/");
+      String[] files = assets.list("");
 
       List<String> listFiles = Arrays.asList(files != null ? files : new String[0]);
       if (listFiles.contains("sentry-debug-meta.properties")) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
listing assets file on the wrong dir (when looking up for sentry-debug-meta.properties)


## :bulb: Motivation and Context
sentry-debug-meta.properties was not being found even if it was there.


## :green_heart: How did you test it?
debugging with proguard enabled

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
