### PR TITLE
benefiting of manifest merging when minSdk < 21

### DIFF
--- a/sentry-android/src/main/AndroidManifest.xml
+++ b/sentry-android/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.sentry.android" />
+<manifest package="io.sentry.android"
+          xmlns:tools="http://schemas.android.com/tools">
+  <uses-sdk
+    tools:overrideLibrary="io.sentry.android.ndk"/>
+</manifest>

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
   <uses-sdk
-    tools:overrideLibrary="io.sentry.android, io.sentry.android.ndk"/>
+    tools:overrideLibrary="io.sentry.android"/>
 
   <application
     android:name=".MyApplication"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
benefiting of manifest merging when minSdk < 21


## :bulb: Motivation and Context
if you wanna support NDK >= 21 but also to support Android SDK < 21, you need to set this merging strategy.
```
  <uses-sdk
    tools:overrideLibrary="io.sentry.android, io.sentry.android.ndk"/>
```

with this PR, you just need:
```
  <uses-sdk
    tools:overrideLibrary="io.sentry.android"/>
```


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
