### PR TITLE
execute beforeBreadcrumb also for scope

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -64,7 +64,7 @@ public final class Hub implements IHub {
 
   private static StackItem createRootStackItem(@NotNull SentryOptions options) {
     validateOptions(options);
-    Scope scope = new Scope(options.getMaxBreadcrumbs());
+    Scope scope = new Scope(options.getMaxBreadcrumbs(), options.getBeforeBreadcrumb());
     ISentryClient client = new SentryClient(options);
     return new StackItem(client, scope);
   }
@@ -218,7 +218,7 @@ public final class Hub implements IHub {
           breadcrumb = executeBeforeBreadcrumb(callback, breadcrumb, hint);
         }
         if (breadcrumb != null) {
-          item.scope.addBreadcrumb(breadcrumb);
+          item.scope.addBreadcrumb(breadcrumb, false);
         }
       } else {
         logIfNotNull(
@@ -414,7 +414,7 @@ public final class Hub implements IHub {
       } catch (CloneNotSupportedException e) {
         // TODO: Why do we need to deal with this? We must guarantee clone is possible here!
         logIfNotNull(options.getLogger(), SentryLevel.ERROR, "Clone not supported");
-        clonedScope = new Scope(options.getMaxBreadcrumbs());
+        clonedScope = new Scope(options.getMaxBreadcrumbs(), options.getBeforeBreadcrumb());
       }
       StackItem cloneItem = new StackItem(item.client, clonedScope);
       clone.stack.push(cloneItem);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
execute beforeBreadcrumb also for scope


## :bulb: Motivation and Context
beforeBreadcrumb was not being executed when breadcrumbs were added directly to the scope


## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
refactor it, we have a design flaw here, I don't like the solution, but we need to have it done till tomorrow.