### PR TITLE
ref: Don't avoid exception type minification

### DIFF
--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -25,9 +25,6 @@
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
 
-# Prevent proguard from minifying exception type names
--keep class * extends java.lang.Exception
-
 # Prevent R8 from leaving Data object members always null
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;


### PR DESCRIPTION
See: https://github.com/getsentry/sentry/pull/15795
Once merged/deployed, sentry.io would not longer require exception types not to be minified.