### PR TITLE
fix desugaring Gson/AGP

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,5 +1,5 @@
 object Config {
-    val kotlinVersion = "1.3.60"
+    val kotlinVersion = "1.3.61"
     val kotlinStdLib = "stdlib-jdk8"
 
     object BuildPlugins {
@@ -20,7 +20,8 @@ object Config {
     object Libs {
         val appCompat = "androidx.appcompat:appcompat:1.1.0"
         val timber = "com.jakewharton.timber:timber:4.7.1"
-        val gson = "com.google.code.gson:gson:2.8.6"
+        // only bump gson if https://github.com/google/gson/issues/1597 is fixed
+        val gson = "com.google.code.gson:gson:2.8.5"
         val leakCanary = "com.squareup.leakcanary:leakcanary-android:2.0-beta-4"
     }
 

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -9,7 +9,7 @@
 # Gson specific classes
 -dontwarn sun.misc.**
 -keep class com.google.gson.** { *; }
-#-keep class com.google.gson.stream.** { *; }
+-keep class sun.misc.Unsafe { *; }
 
 # Application classes that will be serialized/deserialized over Gson
 -keep class io.sentry.core.** { *; }
@@ -29,5 +29,10 @@
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;
 }
+
+# Keep jetbrains annotations
+-keep @interface com.jakewharton.nopen.annotation.** { *; }
+-keep @interface org.jetbrains.annotations.** { *; }
+
 
 ##---------------End: proguard configuration for Gson  ----------

--- a/sentry-android-core/src/main/java/io/sentry/android/core/UnknownPropertiesTypeAdapterFactory.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/UnknownPropertiesTypeAdapterFactory.java
@@ -86,7 +86,8 @@ final class UnknownPropertiesTypeAdapterFactory implements TypeAdapterFactory {
     public T read(final JsonReader in) {
       // In its simplest solution, we can just collect a JSON tree because its much easier to
       // process
-      JsonElement jsonElement = JsonParser.parseReader(in);
+      JsonParser parser = new JsonParser();
+      JsonElement jsonElement = parser.parse(in);
 
       if (jsonElement == null || jsonElement.isJsonNull()) {
         return null;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
make gson retro compatible with older versions of AGP


## :bulb: Motivation and Context
when compiling a project and using the latest version of sentry-android, an error was happening due to:
https://github.com/google/gson/issues/1597

investigation due to:
https://github.com/getsentry/sentry-android/issues/171

## :green_heart: How did you test it?
compiling a sample project with all the AGP versions >= 3 till the latest one.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
find a way to compile a sample project with all AGP versions, to be sure that we don't release something which is breaking the build for older versions.