### PR TITLE
linking sentry-native directly to be able to debug it

### DIFF
--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -48,11 +48,3 @@ JNIEXPORT void JNICALL Java_io_sentry_android_ndk_SentryNdk_initSentryNative(JNI
     sentry_options_set_dsn(options, (*env)->GetStringUTFChars(env, dsn, 0));
     sentry_init(options);
 }
-
-JNIEXPORT void JNICALL Java_io_sentry_android_ndk_SentryNdk_verificationEventNative(JNIEnv *env) {
-    sentry_value_t event = sentry_value_new_event();
-    sentry_value_set_by_key(event, "NDK verification event",
-                            sentry_value_new_string("The NDK integration works!"));
-
-    sentry_capture_event(event);
-}

--- a/sentry-sample/CMakeLists.txt
+++ b/sentry-sample/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.4.1)
 project("sentry-sample")
 
-add_library(native-sample SHARED src/main/cpp/native-sample.cpp)
+add_subdirectory(../sentry-android-ndk/${SENTRY_NATIVE_SRC} "${CMAKE_CURRENT_BINARY_DIR}/sentry-native")
+include_directories(../sentry-android-ndk/${SENTRY_NATIVE_SRC}/include)
+
 find_library(LOG_LIB log)
-target_link_libraries(native-sample ${LOG_LIB})
+add_library(native-sample SHARED src/main/cpp/native-sample.cpp)
+
+target_link_libraries(native-sample "sentry" ${LOG_LIB})

--- a/sentry-sample/build.gradle.kts
+++ b/sentry-sample/build.gradle.kts
@@ -9,14 +9,21 @@ android {
 
     defaultConfig {
         applicationId = "io.sentry.sample"
-        minSdkVersion(Config.Android.minSdkVersion)
+        minSdkVersion(Config.Android.minSdkVersionNdk)
         targetSdkVersion(Config.Android.targetSdkVersion)
         versionCode = 1
         versionName = "1.0"
 
         externalNativeBuild {
+            val sentryNativeSrc = if (File("${project.projectDir}/sentry-native-local").exists()) {
+                "sentry-native-local"
+            } else {
+                "sentry-native"
+            }
+
             cmake {
                 arguments.add(0, "-DANDROID_STL=c++_static")
+                arguments.add(0, "-DSENTRY_NATIVE_SRC=$sentryNativeSrc")
             }
         }
 

--- a/sentry-sample/build.gradle.kts
+++ b/sentry-sample/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         versionName = "1.0"
 
         externalNativeBuild {
-            val sentryNativeSrc = if (File("${project.projectDir}/sentry-native-local").exists()) {
+            val sentryNativeSrc = if (File("../sentry-android-ndk/sentry-native-local").exists()) {
                 "sentry-native-local"
             } else {
                 "sentry-native"

--- a/sentry-sample/src/main/cpp/native-sample.cpp
+++ b/sentry-sample/src/main/cpp/native-sample.cpp
@@ -1,5 +1,6 @@
 #include <jni.h>
 #include <android/log.h>
+#include <sentry.h>
 
 #define TAG "sentry-sample"
 
@@ -9,6 +10,16 @@ JNIEXPORT void JNICALL Java_io_sentry_sample_NativeSample_crash(JNIEnv *env, jcl
     __android_log_print(ANDROID_LOG_WARN, TAG, "About to crash.");
     char *ptr = 0;
     *ptr += 1;
+}
+
+JNIEXPORT void JNICALL Java_io_sentry_sample_NativeSample_message(JNIEnv *env, jclass cls) {
+    __android_log_print(ANDROID_LOG_WARN, TAG, "About to crash.");
+    sentry_value_t event = sentry_value_new_message_event(
+            /*   level */ SENTRY_LEVEL_INFO,
+            /*  logger */ "custom",
+            /* message */ "It works!"
+    );
+    sentry_capture_event(event);
 }
 
 }

--- a/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
@@ -59,7 +59,7 @@ public class MainActivity extends AppCompatActivity {
 
     findViewById(R.id.native_crash).setOnClickListener(view -> NativeSample.crash());
 
-    findViewById(R.id.native_capture).setOnClickListener(view -> NativeSample.verificationEvent());
+    findViewById(R.id.native_capture).setOnClickListener(view -> NativeSample.message());
 
     findViewById(R.id.anr)
         .setOnClickListener(

--- a/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
@@ -1,22 +1,11 @@
 package io.sentry.sample;
 
-import java.lang.reflect.Method;
-
 public class NativeSample {
   public static native void crash();
 
+  public static native void message();
+
   static {
     System.loadLibrary("native-sample");
-  }
-
-  // TODO: Raise from native-sample.cpp instead
-  public static void verificationEvent() {
-    try {
-      Class<?> cls = Class.forName("io.sentry.android.ndk.SentryNdk");
-      Method method = cls.getMethod("verificationEvent");
-      method.invoke(null);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
linking sentry-native directly to be able to debug it.


## :bulb: Motivation and Context
it was not possible to debug sentry-native if not defining methods in sentry.c.


## :green_heart: How did you test it?
debugging it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
