### PR TITLE
fix Android bug on API 24 and 25 about threads/stacktraces

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
@@ -7,6 +7,7 @@ import io.sentry.core.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.annotations.TestOnly;
 
 final class SentryThreadFactory {
 
@@ -17,12 +18,23 @@ final class SentryThreadFactory {
         Objects.requireNonNull(sentryStackTraceFactory, "The SentryStackTraceFactory is required.");
   }
 
-  // Assumes its being called from the crashed (errored) thread.
+  // Assumes its being called from the crashed thread.
   List<SentryThread> getCurrentThreads() {
-    Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
+    return getCurrentThreads(Thread.getAllStackTraces());
+  }
+
+  // Assumes its being called from the crashed thread.
+  @TestOnly
+  List<SentryThread> getCurrentThreads(Map<Thread, StackTraceElement[]> threads) {
     List<SentryThread> result = new ArrayList<>();
 
     Thread currentThread = Thread.currentThread();
+
+    // https://issuetracker.google.com/issues/64122757
+    if (!threads.containsKey(currentThread)) {
+      threads.put(currentThread, currentThread.getStackTrace());
+    }
+
     for (Map.Entry<Thread, StackTraceElement[]> item : threads.entrySet()) {
       result.add(getSentryThread(currentThread, item.getValue(), item.getKey()));
     }

--- a/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
@@ -2,6 +2,7 @@ package io.sentry.core
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
@@ -26,4 +27,15 @@ class SentryThreadFactoryTest {
     @Test
     fun `when currentThreads is called, some thread stack frames are captured`() =
         assertTrue(sut.currentThreads.filter { it.stacktrace != null }.any { it.stacktrace.frames.count() > 0 })
+
+    @Test
+    fun `when getAllStackTraces don't return the current thread, add it manually`() {
+        val stackTraces = Thread.getAllStackTraces()
+        val currentThread = Thread.currentThread()
+        stackTraces.remove(currentThread)
+
+        val threads = sut.getCurrentThreads(stackTraces)
+
+        assertNotNull(threads.firstOrNull { it.id == currentThread.id })
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix Android bug on API 24 and 25 about threads/stack traces.
https://issuetracker.google.com/issues/64122757

## :bulb: Motivation and Context
if not fixed, threads and stack traces will be incompleted.


## :green_heart: How did you test it?
unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
