### PR TITLE
feat: addBreadcrumb overloads

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/IHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/IHub.java
@@ -3,6 +3,7 @@ package io.sentry.core;
 import io.sentry.core.protocol.SentryId;
 import io.sentry.core.protocol.User;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface IHub {
@@ -33,6 +34,16 @@ public interface IHub {
 
   default void addBreadcrumb(Breadcrumb breadcrumb) {
     addBreadcrumb(breadcrumb, null);
+  }
+
+  default void addBreadcrumb(@NotNull String message) {
+    addBreadcrumb(new Breadcrumb(message));
+  }
+
+  default void addBreadcrumb(@NotNull String message, @NotNull String category) {
+    Breadcrumb breadcrumb = new Breadcrumb(message);
+    breadcrumb.setCategory(category);
+    addBreadcrumb(breadcrumb);
   }
 
   void setLevel(SentryLevel level);

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -107,6 +107,14 @@ public final class Sentry {
     getCurrentHub().addBreadcrumb(breadcrumb);
   }
 
+  public static void addBreadcrumb(@NotNull String message) {
+    getCurrentHub().addBreadcrumb(message);
+  }
+
+  public static void addBreadcrumb(@NotNull String message, @NotNull String category) {
+    getCurrentHub().addBreadcrumb(message, category);
+  }
+
   public static void setLevel(@Nullable SentryLevel level) {
     getCurrentHub().setLevel(level);
   }

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -202,6 +202,34 @@ class HubTest {
     }
 
     @Test
+    fun `when addBreadcrumb is called with message and category, breadcrumb object has values`() {
+        val options = SentryOptions()
+        options.cacheDirPath = file.absolutePath
+        options.dsn = "https://key@sentry.io/proj"
+        options.setSerializer(mock())
+        val sut = Hub(options)
+        var breadcrumbs: Queue<Breadcrumb>? = null
+        sut.configureScope { breadcrumbs = it.breadcrumbs }
+        sut.addBreadcrumb("message", "category")
+        assertEquals("message", breadcrumbs!!.single().message)
+        assertEquals("category", breadcrumbs!!.single().category)
+    }
+
+    @Test
+    fun `when addBreadcrumb is called with message, breadcrumb object has value`() {
+        val options = SentryOptions()
+        options.cacheDirPath = file.absolutePath
+        options.dsn = "https://key@sentry.io/proj"
+        options.setSerializer(mock())
+        val sut = Hub(options)
+        var breadcrumbs: Queue<Breadcrumb>? = null
+        sut.configureScope { breadcrumbs = it.breadcrumbs }
+        sut.addBreadcrumb("message", "category")
+        assertEquals("message", breadcrumbs!!.single().message)
+        assertEquals("category", breadcrumbs!!.single().category)
+    }
+
+    @Test
     fun `when flush is called on disabled client, no-op`() {
         val options = SentryOptions()
         options.cacheDirPath = file.absolutePath


### PR DESCRIPTION
Common use case is: `Sentry.addBreadcrumb("bla");`

Or, also used for the guide: `Sentry.addBreadcrumb(activity.getComponentName().flattenToShortString() + "started", "activity");`