### PR TITLE
added executor for caching values out of the main thread

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -74,7 +74,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     this.options = Objects.requireNonNull(options, "The SentryOptions is required.");
 
     ExecutorService executorService = Executors.newSingleThreadExecutor();
-    contextData = executorService.submit(this::loadContextData);
+    contextData = executorService.submit(() -> loadContextData());
 
     executorService.shutdown();
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -59,6 +59,12 @@ import org.jetbrains.annotations.Nullable;
 
 final class DefaultAndroidEventProcessor implements EventProcessor {
 
+  private static final String PROGUARD_UUID = "proGuardUuids";
+  private static final String ROOTED = "rooted";
+  private static final String ANDROID_ID = "androidId";
+  private static final String KERNEL_VERSION = "kernelVersion";
+  private static final String EMULATOR = "emulator";
+
   // it could also be a parameter and get from Sentry.init(...)
   private static final Date appStartTime = DateUtils.getCurrentDateTime();
   final Context context;
@@ -83,22 +89,23 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     Map<String, Object> map = new HashMap<>();
     String[] proGuardUuids = getProGuardUuids();
     if (proGuardUuids != null) {
-      map.put("proGuardUuids", proGuardUuids);
+      map.put(PROGUARD_UUID, proGuardUuids);
     }
 
-    map.put("rooted", isRooted());
+    map.put(ROOTED, isRooted());
 
     String androidId = getAndroidId();
     if (androidId != null) {
-      map.put("androidId", androidId);
+      map.put(ANDROID_ID, androidId);
     }
 
     String kernelVersion = getKernelVersion();
     if (kernelVersion != null) {
-      map.put("kernelVersion", kernelVersion);
+      map.put(KERNEL_VERSION, kernelVersion);
     }
 
-    map.put("emulator", isEmulator());
+    // its not IO, but it has been cached in the old version as well
+    map.put(EMULATOR, isEmulator());
 
     return map;
   }
@@ -156,7 +163,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private List<DebugImage> getDebugImages() {
     String[] uuids = null;
     try {
-      Object proGuardUuids = contextData.get().get("proGuardUuids");
+      Object proGuardUuids = contextData.get().get(PROGUARD_UUID);
       if (proGuardUuids != null) {
         uuids = (String[]) proGuardUuids;
       }
@@ -299,7 +306,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     device.setOrientation(getOrientation());
 
     try {
-      Object emulator = contextData.get().get("emulator");
+      Object emulator = contextData.get().get(EMULATOR);
       if (emulator != null) {
         device.setSimulator((Boolean) emulator);
       }
@@ -732,12 +739,12 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     os.setBuild(Build.DISPLAY);
 
     try {
-      Object kernelVersion = contextData.get().get("kernelVersion");
+      Object kernelVersion = contextData.get().get(KERNEL_VERSION);
       if (kernelVersion != null) {
         os.setKernelVersion((String) kernelVersion);
       }
 
-      Object rooted = contextData.get().get("rooted");
+      Object rooted = contextData.get().get(ROOTED);
       if (rooted != null) {
         os.setRooted((Boolean) rooted);
       }
@@ -860,7 +867,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     User user = new User();
 
     try {
-      Object androidId = contextData.get().get("androidId");
+      Object androidId = contextData.get().get(ANDROID_ID);
 
       if (androidId != null) {
         user.setId((String) androidId);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -56,21 +56,24 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 final class DefaultAndroidEventProcessor implements EventProcessor {
 
-  private static final String PROGUARD_UUID = "proGuardUuids";
-  private static final String ROOTED = "rooted";
-  private static final String ANDROID_ID = "androidId";
-  private static final String KERNEL_VERSION = "kernelVersion";
-  private static final String EMULATOR = "emulator";
+  @TestOnly static final String PROGUARD_UUID = "proGuardUuids";
+  @TestOnly static final String ROOTED = "rooted";
+  @TestOnly static final String ANDROID_ID = "androidId";
+  @TestOnly static final String KERNEL_VERSION = "kernelVersion";
+  @TestOnly static final String EMULATOR = "emulator";
 
   // it could also be a parameter and get from Sentry.init(...)
   private static final Date appStartTime = DateUtils.getCurrentDateTime();
-  final Context context;
+
+  @TestOnly final Context context;
+
   private final SentryOptions options;
 
-  private final Future<Map<String, Object>> contextData;
+  @TestOnly final Future<Map<String, Object>> contextData;
 
   public DefaultAndroidEventProcessor(Context context, SentryOptions options) {
     this.context =

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -56,7 +56,10 @@ final class ManifestMetadataReader {
 
         String dsn = metadata.getString(DSN_KEY, null);
         if (dsn == null) {
-          logIfNotNull(options.getLogger(), SentryLevel.FATAL, "DSN is required. Use empty string to disable SDK.");
+          logIfNotNull(
+              options.getLogger(),
+              SentryLevel.FATAL,
+              "DSN is required. Use empty string to disable SDK.");
         } else if (dsn.isEmpty()) {
           logIfNotNull(
               options.getLogger(), SentryLevel.DEBUG, "DSN is empty, disabling sentry-android");

--- a/sentry-android-core/src/test/assets/sentry-debug-meta.properties
+++ b/sentry-android-core/src/test/assets/sentry-debug-meta.properties
@@ -1,0 +1,1 @@
+io.sentry.ProguardUuids=test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -5,6 +5,11 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import io.sentry.android.core.DefaultAndroidEventProcessor.ANDROID_ID
+import io.sentry.android.core.DefaultAndroidEventProcessor.EMULATOR
+import io.sentry.android.core.DefaultAndroidEventProcessor.KERNEL_VERSION
+import io.sentry.android.core.DefaultAndroidEventProcessor.PROGUARD_UUID
+import io.sentry.android.core.DefaultAndroidEventProcessor.ROOTED
 import io.sentry.core.ILogger
 import io.sentry.core.SentryEvent
 import io.sentry.core.SentryOptions
@@ -68,7 +73,7 @@ class DefaultAndroidEventProcessorTest {
         event = processor.process(event, null)
         assertNotNull(event.user)
         assertNotNull(event.contexts.app)
-//        assertNotNull(event.debugMeta) file doesnt exist
+        assertEquals("test", event.debugMeta.images[0].uuid)
         assertNotNull(event.sdk)
         assertNotNull(event.release)
         assertNotNull(event.dist)
@@ -87,5 +92,17 @@ class DefaultAndroidEventProcessorTest {
         assertNull(event.sdk)
         assertNull(event.release)
         assertNull(event.dist)
+    }
+
+    @Test
+    fun `Executor service should be called on ctor`() {
+        val processor = DefaultAndroidEventProcessor(context, fixture.options)
+        val contextData = processor.contextData.get()
+        assertNotNull(contextData)
+        assertEquals("test", (contextData[PROGUARD_UUID] as Array<*>)[0])
+        assertNotNull(contextData[ROOTED])
+        assertNotNull(contextData[ANDROID_ID])
+        assertNotNull(contextData[KERNEL_VERSION])
+        assertNotNull(contextData[EMULATOR])
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
added executor for caching values out of the main thread.


## :bulb: Motivation and Context
right now every capture exception or message will do IO on the main thread and data is static, so it may be cached.


## :green_heart: How did you test it?
executing and StrictMode.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
