### PR TITLE
added android transport gate

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -32,6 +32,8 @@ final class AndroidOptionsInitializer {
 
     options.addEventProcessor(new DefaultAndroidEventProcessor(context, options));
     options.setSerializer(new AndroidSerializer(options.getLogger()));
+
+    options.setTransportGate(new AndroidTransportGate(context, options.getLogger()));
   }
 
   private static void setDefaultInApp(Context context, SentryOptions options) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransportGate.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransportGate.java
@@ -1,7 +1,7 @@
 package io.sentry.android.core;
 
 import android.content.Context;
-import io.sentry.android.core.util.CheckConnectivity;
+import io.sentry.android.core.util.ConnectivityChecker;
 import io.sentry.core.ILogger;
 import io.sentry.core.transport.ITransportGate;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +18,7 @@ final class AndroidTransportGate implements ITransportGate {
 
   @Override
   public boolean isSendingAllowed() {
-    Boolean connected = CheckConnectivity.isConnected(context, loger);
+    Boolean connected = ConnectivityChecker.isConnected(context, loger);
     // let's assume its connected if there's no permission or something as we can't really know
     // whether is online or not.
     return connected != null ? connected : true;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransportGate.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransportGate.java
@@ -1,0 +1,26 @@
+package io.sentry.android.core;
+
+import android.content.Context;
+import io.sentry.android.core.util.CheckConnectivity;
+import io.sentry.core.ILogger;
+import io.sentry.core.transport.ITransportGate;
+import org.jetbrains.annotations.NotNull;
+
+final class AndroidTransportGate implements ITransportGate {
+
+  private final Context context;
+  private final ILogger loger;
+
+  AndroidTransportGate(@NotNull Context context, @NotNull ILogger loger) {
+    this.context = context;
+    this.loger = loger;
+  }
+
+  @Override
+  public boolean isSendingAllowed() {
+    Boolean connected = CheckConnectivity.isConnected(context, loger);
+    // let's assume its connected if there's no permission or something as we can't really know
+    // whether is online or not.
+    return connected != null ? connected : true;
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -3,7 +3,6 @@ package io.sentry.android.core;
 import static android.content.Context.ACTIVITY_SERVICE;
 import static io.sentry.core.ILogger.logIfNotNull;
 
-import android.Manifest;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
@@ -12,7 +11,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
-import android.net.ConnectivityManager;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.os.Environment;
@@ -21,7 +19,7 @@ import android.os.StatFs;
 import android.os.SystemClock;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
-import io.sentry.android.core.util.Permissions;
+import io.sentry.android.core.util.CheckConnectivity;
 import io.sentry.core.DateUtils;
 import io.sentry.core.EventProcessor;
 import io.sentry.core.ILogger;
@@ -305,7 +303,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       device.setBatteryLevel(getBatteryLevel(batteryIntent));
       device.setCharging(isCharging(batteryIntent));
     }
-    device.setOnline(isConnected());
+    device.setOnline(CheckConnectivity.isConnected(context, options.getLogger()));
     device.setOrientation(getOrientation());
 
     try {
@@ -470,43 +468,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       log(SentryLevel.ERROR, "Error getting device charging state.", e);
       return null;
     }
-  }
-
-  /**
-   * Check whether the application has internet access at a point in time.
-   *
-   * @return true if the application has internet access
-   */
-  private Boolean isConnected() {
-    ConnectivityManager connectivityManager =
-        (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-    if (connectivityManager == null) {
-      log(SentryLevel.INFO, "ConnectivityManager is null and cannot check network status");
-      return null;
-    }
-    return getActiveNetworkInfo(connectivityManager);
-    // getActiveNetworkInfo might return null if VPN doesn't specify its
-    // underlying network
-
-    // when min. API 24, use:
-    // connectivityManager.registerDefaultNetworkCallback(...)
-  }
-
-  @SuppressWarnings({"deprecation", "MissingPermission"})
-  private Boolean getActiveNetworkInfo(ConnectivityManager connectivityManager) {
-    if (!Permissions.hasPermission(context, Manifest.permission.ACCESS_NETWORK_STATE)) {
-      log(SentryLevel.INFO, "No permission (ACCESS_NETWORK_STATE) to check network status.");
-      return null;
-    }
-
-    // do not import class or deprecation lint will throw
-    android.net.NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
-
-    if (activeNetwork != null) {
-      return activeNetwork.isConnected();
-    }
-    log(SentryLevel.INFO, "NetworkInfo is null and cannot check network status");
-    return null;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -19,7 +19,7 @@ import android.os.StatFs;
 import android.os.SystemClock;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
-import io.sentry.android.core.util.CheckConnectivity;
+import io.sentry.android.core.util.ConnectivityChecker;
 import io.sentry.core.DateUtils;
 import io.sentry.core.EventProcessor;
 import io.sentry.core.ILogger;
@@ -303,7 +303,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       device.setBatteryLevel(getBatteryLevel(batteryIntent));
       device.setCharging(isCharging(batteryIntent));
     }
-    device.setOnline(CheckConnectivity.isConnected(context, options.getLogger()));
+    device.setOnline(ConnectivityChecker.isConnected(context, options.getLogger()));
     device.setOrientation(getOrientation());
 
     try {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/util/CheckConnectivity.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/util/CheckConnectivity.java
@@ -1,0 +1,54 @@
+package io.sentry.android.core.util;
+
+import android.Manifest;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import io.sentry.core.ILogger;
+import io.sentry.core.SentryLevel;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class CheckConnectivity {
+
+  private CheckConnectivity() {}
+
+  /**
+   * Check whether the application has internet access at a point in time.
+   *
+   * @return true if the application has internet access
+   */
+  public static @Nullable Boolean isConnected(@NotNull Context context, @NotNull ILogger logger) {
+    ConnectivityManager connectivityManager =
+        (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+    if (connectivityManager == null) {
+      logger.log(SentryLevel.INFO, "ConnectivityManager is null and cannot check network status");
+      return null;
+    }
+    return getActiveNetworkInfo(context, connectivityManager, logger);
+    // getActiveNetworkInfo might return null if VPN doesn't specify its
+    // underlying network
+
+    // when min. API 24, use:
+    // connectivityManager.registerDefaultNetworkCallback(...)
+  }
+
+  @SuppressWarnings({"deprecation", "MissingPermission"})
+  private static Boolean getActiveNetworkInfo(
+      Context context, ConnectivityManager connectivityManager, ILogger logger) {
+    if (!Permissions.hasPermission(context, Manifest.permission.ACCESS_NETWORK_STATE)) {
+      logger.log(SentryLevel.INFO, "No permission (ACCESS_NETWORK_STATE) to check network status.");
+      return null;
+    }
+
+    // do not import class or deprecation lint will throw
+    android.net.NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
+
+    if (activeNetwork != null) {
+      return activeNetwork.isConnected();
+    }
+    logger.log(SentryLevel.INFO, "NetworkInfo is null and cannot check network status");
+    return null;
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/util/ConnectivityChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/util/ConnectivityChecker.java
@@ -10,9 +10,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
-public final class CheckConnectivity {
+public final class ConnectivityChecker {
 
-  private CheckConnectivity() {}
+  private ConnectivityChecker() {}
 
   /**
    * Check whether the application has internet access at a point in time.

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -100,6 +100,18 @@ class AndroidOptionsInitializerTest {
         assertTrue(sentryOptions.inAppExcludes.contains("android."))
     }
 
+    @Test
+    fun `init should set Android transport gate`() {
+        val sentryOptions = SentryAndroidOptions()
+        val mockContext = createMockContext()
+        val mockLogger = mock<ILogger>()
+
+        AndroidOptionsInitializer.init(sentryOptions, mockContext, mockLogger)
+
+        assertNotNull(sentryOptions.transportGate)
+        assertTrue(sentryOptions.transportGate is AndroidTransportGate)
+    }
+
     private fun createMockContext(): Context {
         val mockContext = mock<Context> {
             on { applicationContext } doReturn context

--- a/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
@@ -3,23 +3,18 @@ package io.sentry.core;
 import io.sentry.core.cache.IEventCache;
 import io.sentry.core.transport.AsyncConnection;
 import io.sentry.core.transport.IBackOffIntervalStrategy;
-import io.sentry.core.transport.ITransportGate;
 
 final class AsyncConnectionFactory {
   private AsyncConnectionFactory() {}
 
   public static AsyncConnection create(SentryOptions options, IEventCache eventCache) {
-    // TODO this should be made configurable at least for the Android case where we can
-    // just not attempt to send if the device is offline.
-    ITransportGate alwaysOn = () -> true;
-
     IBackOffIntervalStrategy linearBackoff = attempt -> attempt * 500;
 
     // the connection doesn't do any retries of failed sends and can hold at most the same number
     // of pending events as there are being cached. The rest is dropped.
     return new AsyncConnection(
         options.getTransport(),
-        alwaysOn,
+        options.getTransportGate(),
         linearBackoff,
         eventCache,
         0,

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -8,6 +8,7 @@ import io.sentry.core.hints.Cached;
 import io.sentry.core.protocol.SentryId;
 import io.sentry.core.transport.Connection;
 import io.sentry.core.transport.ITransport;
+import io.sentry.core.transport.ITransportGate;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -45,8 +46,13 @@ public final class SentryClient implements ISentryClient {
       options.setTransport(transport);
     }
 
-    if (connection == null) {
+    ITransportGate transportGate = options.getTransportGate();
+    if (transportGate == null) {
+      transportGate = () -> true;
+      options.setTransportGate(transportGate);
+    }
 
+    if (connection == null) {
       // TODO this is obviously provisional and should be constructed based on the config in options
       IEventCache cache = new DiskCache(options);
 

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -4,6 +4,7 @@ import static io.sentry.core.ILogger.logIfNotNull;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.core.transport.ITransport;
+import io.sentry.core.transport.ITransportGate;
 import java.io.File;
 import java.net.Proxy;
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ public class SentryOptions {
   private @NotNull List<String> inAppExcludes;
   private @NotNull List<String> inAppIncludes;
   private @Nullable ITransport transport;
+  private @Nullable ITransportGate transportGate;
   private @Nullable String dist;
 
   public void addEventProcessor(@NotNull EventProcessor eventProcessor) {
@@ -245,6 +247,14 @@ public class SentryOptions {
 
   public void setDist(@Nullable String dist) {
     this.dist = dist;
+  }
+
+  public @Nullable ITransportGate getTransportGate() {
+    return transportGate;
+  }
+
+  public void setTransportGate(@Nullable ITransportGate transportGate) {
+    this.transportGate = transportGate;
   }
 
   public interface BeforeSendCallback {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
added an android transport gate to check if the device is online or not, so the event only will try to send if it actually has a connected network.


## :bulb: Motivation and Context
check if the device has a connected network before trying to send the event, right now even if it's not connected anywhere, we are trying to send, so wasting resources.


## :green_heart: How did you test it?
unit tests on the setup, but it's hard to mock the whole network conf. of the android framework.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
