### PR TITLE
Remove redundant times(1) for Mockito.verify

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -2,7 +2,6 @@ package io.sentry.android.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import io.sentry.core.Hub
 import io.sentry.core.SentryOptions
@@ -49,6 +48,6 @@ class EnvelopeFileObserverIntegrationTest {
         val hub = Hub(options)
         verify(integrationMock).register(hub, options)
         hub.close()
-        verify(integrationMock, times(1)).close()
+        verify(integrationMock).close()
     }
 }

--- a/sentry-core/src/test/java/io/sentry/core/EnvelopeSenderTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/EnvelopeSenderTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.argWhere
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.protocol.SentryId
@@ -71,7 +70,7 @@ class EnvelopeSenderTest {
         assertTrue(File(path).exists()) // sanity check
         sut.processEnvelopeFile(path)
 
-        verify(fixture.hub, times(1))!!.captureEvent(eq(expected), any())
+        verify(fixture.hub)!!.captureEvent(eq(expected), any())
         assertFalse(File(path).exists())
         // Additionally make sure we have no errors logged
         verify(fixture.logger, never())!!.log(eq(SentryLevel.ERROR), any(), any<Any>())

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -298,7 +297,7 @@ class HubTest {
         val event = SentryEvent()
         val hint = { }
         sut.captureEvent(event, hint)
-        verify(mockClient, times(1)).captureEvent(eq(event), any(), eq(hint))
+        verify(mockClient).captureEvent(eq(event), any(), eq(hint))
     }
     //endregion
 
@@ -340,7 +339,7 @@ class HubTest {
         sut.bindClient(mockClient)
 
         sut.captureMessage("test")
-        verify(mockClient, times(1)).captureMessage(any(), any(), any())
+        verify(mockClient).captureMessage(any(), any(), any())
     }
 
     @Test
@@ -353,7 +352,7 @@ class HubTest {
         val mockClient = mock<ISentryClient>()
         sut.bindClient(mockClient)
         sut.captureMessage("test")
-        verify(mockClient, times(1)).captureMessage(eq("test"), eq(SentryLevel.INFO), any())
+        verify(mockClient).captureMessage(eq("test"), eq(SentryLevel.INFO), any())
     }
     //endregion
 
@@ -395,7 +394,7 @@ class HubTest {
         sut.bindClient(mockClient)
 
         sut.captureException(Throwable(), Object())
-        verify(mockClient, times(1)).captureException(any(), any(), any())
+        verify(mockClient).captureException(any(), any(), any())
     }
 
     @Test
@@ -409,7 +408,7 @@ class HubTest {
         sut.bindClient(mockClient)
 
         sut.captureException(Throwable())
-        verify(mockClient, times(1)).captureException(any(), any(), isNull())
+        verify(mockClient).captureException(any(), any(), isNull())
     }
     //endregion
 
@@ -426,7 +425,7 @@ class HubTest {
         sut.close()
 
         sut.close()
-        verify(mockClient, times(1)).close() // 1 to close, but next one wont be recorded
+        verify(mockClient).close() // 1 to close, but next one wont be recorded
     }
 
     @Test
@@ -440,7 +439,7 @@ class HubTest {
         sut.bindClient(mockClient)
 
         sut.close()
-        verify(mockClient, times(1)).close()
+        verify(mockClient).close()
     }
     //endregion
 
@@ -475,7 +474,7 @@ class HubTest {
         val scopeCallback = mock<ScopeCallback>()
 
         sut.withScope(scopeCallback)
-        verify(scopeCallback, times(1)).run(any())
+        verify(scopeCallback).run(any())
     }
     //endregion
 
@@ -510,7 +509,7 @@ class HubTest {
         val scopeCallback = mock<ScopeCallback>()
 
         sut.configureScope(scopeCallback)
-        verify(scopeCallback, times(1)).run(any())
+        verify(scopeCallback).run(any())
     }
     //endregion
 
@@ -528,7 +527,7 @@ class HubTest {
             assertTrue(hub.isEnabled)
         }.whenever(mock).register(any(), eq(options))
         Hub(options)
-        verify(mock, times(1)).register(any(), eq(options))
+        verify(mock).register(any(), eq(options))
     }
 
     //region setLevel tests

--- a/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.mockingDetails
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import io.sentry.core.hints.Cached
@@ -105,7 +104,7 @@ class SentryClientTest {
         val sut = fixture.getSut()
         val actual = SentryEvent()
         sut.captureEvent(actual)
-        verify(fixture.connection, times(1)).send(eq(expected), isNull())
+        verify(fixture.connection).send(eq(expected), isNull())
         verifyNoMoreInteractions(fixture.connection)
     }
 

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -2,7 +2,6 @@ package io.sentry.core
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -96,6 +95,6 @@ class UncaughtExceptionHandlerIntegrationTest {
         val hub = Hub(options)
         verify(integrationMock).register(hub, options)
         hub.close()
-        verify(integrationMock, times(1)).close()
+        verify(integrationMock).close()
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
In some parts of the unit tests `Mockito.verify(something, times(1)).someMethod()` is used. This can be simplified to `Mockito.verify(something).someMethod()`.


## :bulb: Motivation and Context
It makes the code simpler and less verbose.


## :green_heart: How did you test it?
By running the tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
None.
