### PR TITLE
Raise code coverage for Dsn to 100%

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Dsn.java
+++ b/sentry-core/src/main/java/io/sentry/core/Dsn.java
@@ -52,7 +52,7 @@ final class Dsn {
         throw new IllegalArgumentException("Invalid DSN: No public key provided.");
       }
       String[] keys = userInfo.split(":", -1);
-      publicKey = keys[0]; // TODO: test lack of delimiter returns whole value as first index
+      publicKey = keys[0];
       if (publicKey == null || publicKey.isEmpty()) {
         throw new IllegalArgumentException("Invalid DSN: No public key provided.");
       }

--- a/sentry-core/src/test/java/io/sentry/core/DsnTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/DsnTest.kt
@@ -7,9 +7,14 @@ import kotlin.test.assertFailsWith
 class DsnTest {
 
     @Test
-    fun `dsn parsed with path`() {
-        val dsn = Dsn("https://key@host/path/id")
+    fun `dsn parsed with path, sets all properties`() {
+        val dsn = Dsn("https://publicKey:secretKey@host/path/id")
+
         assertEquals("https://host/path/api/id/store/", dsn.sentryUri.toURL().toString())
+        assertEquals("publicKey", dsn.publicKey)
+        assertEquals("secretKey", dsn.secretKey)
+        assertEquals("/path/", dsn.path)
+        assertEquals("id", dsn.projectId)
     }
 
     @Test
@@ -39,6 +44,12 @@ class DsnTest {
     @Test
     fun `when no key exists, throws exception`() {
         val ex = assertFailsWith<InvalidDsnException> { Dsn("http://host/id") }
+        assertEquals("java.lang.IllegalArgumentException: Invalid DSN: No public key provided.", ex.message)
+    }
+
+    @Test
+    fun `when only passing secret key, throws exception`() {
+        val ex = assertFailsWith<InvalidDsnException> { Dsn("https://:secret@host/path/id") }
         assertEquals("java.lang.IllegalArgumentException: Invalid DSN: No public key provided.", ex.message)
     }
 }

--- a/sentry-core/src/test/java/io/sentry/core/DsnTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/DsnTest.kt
@@ -3,6 +3,7 @@ package io.sentry.core
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class DsnTest {
 
@@ -33,6 +34,14 @@ class DsnTest {
     fun `dsn parsed with trailing slash`() {
         val dsn = Dsn("http://key@host/id/")
         assertEquals("http://host/api/id/store/", dsn.sentryUri.toURL().toString())
+    }
+
+    @Test
+    fun `dsn parsed with no delimiter for key`() {
+        val dsn = Dsn("https://publicKey@host/id")
+
+        assertEquals("publicKey", dsn.publicKey)
+        assertNull(dsn.secretKey)
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
The code coverage for `Dns` is raised to 100% with this PR.


## :bulb: Motivation and Context
It is better to have a higher code coverage to be able to change code later. Furthermore, one TODO is removed.


## :green_heart: How did you test it?
With unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing

## :crystal_ball: Next steps
None.