### PR TITLE
always call interrupt after InterruptedException

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/EnvelopeSender.java
+++ b/sentry-core/src/main/java/io/sentry/core/EnvelopeSender.java
@@ -159,6 +159,7 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
       try {
         return latch.await(timeoutMills, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         logger.log(ERROR, "Exception while awaiting on lock.", e);
       }
       return false;

--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEvent.java
@@ -124,6 +124,7 @@ final class SendCachedEvent extends DirectoryProcessor {
       try {
         return latch.await(timeoutMills, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         logger.log(ERROR, "Exception while awaiting on lock.", e);
       }
       return false;

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -128,6 +128,7 @@ final class UncaughtExceptionHandlerIntegration
       try {
         return latch.await(timeoutMills, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         logger.log(ERROR, "Exception while awaiting for flush in UncaughtExceptionHint", e);
       }
       return false;

--- a/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
@@ -72,7 +72,7 @@ public class MainActivity extends AppCompatActivity {
               try {
                 Thread.sleep(2500);
               } catch (InterruptedException e) {
-                return;
+                Thread.currentThread().interrupt();
               }
             });
   }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
always call interrupt after InterruptedException.

## :bulb: Motivation and Context
for my understanding, this should be always done if we don't have full control of the thread.
eg https://dzone.com/articles/why-do-we-need-threadcurrentthreadinterrupt-in-int


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
