### PR TITLE
fix(sentry-java): Contexts belong on the Scope

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Scope.java
+++ b/sentry-core/src/main/java/io/sentry/core/Scope.java
@@ -3,7 +3,6 @@ package io.sentry.core;
 import io.sentry.core.protocol.Contexts;
 import io.sentry.core.protocol.User;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -149,11 +148,11 @@ public final class Scope implements Cloneable {
     this.extra.remove(key);
   }
 
-  public Contexts getContexts() {
+  public @NotNull Contexts getContexts() {
     return contexts;
   }
 
-  public void setContexts(Contexts contexts) {
+  public void setContexts(@NotNull Contexts contexts) {
     this.contexts = contexts;
   }
 
@@ -207,18 +206,9 @@ public final class Scope implements Cloneable {
       }
     }
 
+    clone.extra = extraClone;
 
-    final Contexts contextsRef = contexts;
-
-    Contexts contextsClone = new Contexts();
-
-    for (Map.Entry<String, Object> item : contextsRef.entrySet()) {
-      if (item != null) {
-        contextsClone.put(item.getKey(), item.getValue());
-      }
-    }
-
-    clone.contexts = contextsRef;
+    clone.contexts = new Contexts(contexts);
 
     return clone;
   }

--- a/sentry-core/src/main/java/io/sentry/core/Scope.java
+++ b/sentry-core/src/main/java/io/sentry/core/Scope.java
@@ -1,5 +1,6 @@
 package io.sentry.core;
 
+import io.sentry.core.protocol.Contexts;
 import io.sentry.core.protocol.User;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,6 +22,8 @@ public final class Scope implements Cloneable {
   private @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
   private @NotNull Map<String, Object> extra = new ConcurrentHashMap<>();
   private @NotNull List<EventProcessor> eventProcessors = new CopyOnWriteArrayList<>();
+  private Contexts contexts = new Contexts();
+
   private final @NotNull SentryOptions options;
 
   public Scope(final @NotNull SentryOptions options) {
@@ -146,6 +149,14 @@ public final class Scope implements Cloneable {
     this.extra.remove(key);
   }
 
+  public Contexts getContexts() {
+    return contexts;
+  }
+
+  public void setContexts(Contexts contexts) {
+    this.contexts = contexts;
+  }
+
   private @NotNull Queue<Breadcrumb> createBreadcrumbsList(final int maxBreadcrumb) {
     return SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(maxBreadcrumb));
   }
@@ -188,7 +199,7 @@ public final class Scope implements Cloneable {
 
     final Map<String, Object> extraRef = extra;
 
-    Map<String, Object> extraClone = new HashMap<>();
+    Map<String, Object> extraClone = new ConcurrentHashMap<>();
 
     for (Map.Entry<String, Object> item : extraRef.entrySet()) {
       if (item != null) {
@@ -196,7 +207,18 @@ public final class Scope implements Cloneable {
       }
     }
 
-    clone.extra = extraClone;
+
+    final Contexts contextsRef = contexts;
+
+    Contexts contextsClone = new Contexts();
+
+    for (Map.Entry<String, Object> item : contextsRef.entrySet()) {
+      if (item != null) {
+        contextsClone.put(item.getKey(), item.getValue());
+      }
+    }
+
+    clone.contexts = contextsRef;
 
     return clone;
   }

--- a/sentry-core/src/main/java/io/sentry/core/protocol/Contexts.java
+++ b/sentry-core/src/main/java/io/sentry/core/protocol/Contexts.java
@@ -1,9 +1,14 @@
 package io.sentry.core.protocol;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class Contexts extends ConcurrentHashMap<String, Object> {
   private static final long serialVersionUID = 252445813254943011L;
+
+  public Contexts(Map<String, Object> initialValues) {
+    super(initialValues);
+  }
 
   private <T> T toContextType(String key, Class<T> clazz) {
     Object item = get(key);

--- a/sentry-core/src/test/java/io/sentry/core/ScopeTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/ScopeTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.core
 
+import io.sentry.core.protocol.App
 import io.sentry.core.protocol.User
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,6 +24,7 @@ class ScopeTest {
 
         scope.user = user
         scope.transaction = "transaction"
+        scope.contexts.app = App()
 
         val fingerprints = mutableListOf("abc", "def")
         scope.fingerprint = fingerprints
@@ -47,6 +49,8 @@ class ScopeTest {
         assertNotNull(clone)
         assertNotSame(scope, clone)
         assertNotSame(scope.user, clone.user)
+        assertNotSame(scope.contexts, clone.contexts)
+        assertNotSame(scope.contexts.app, clone.contexts.app)
         assertNotSame(scope.fingerprint, clone.fingerprint)
         assertNotSame(scope.breadcrumbs, clone.breadcrumbs)
         assertNotSame(scope.tags, clone.tags)
@@ -65,6 +69,8 @@ class ScopeTest {
 
         scope.user = user
         scope.transaction = "transaction"
+
+        scope.contexts.app = App()
 
         val fingerprints = mutableListOf("abc")
         scope.fingerprint = fingerprints


### PR DESCRIPTION
This is work to get `sentry-core` where it can be the base of `sentry-java` and its integrations.
The long term goal is to [merge this repo into `sentry-java`](https://github.com/getsentry/sentry-java) instead on a orphan branch and keep the `1.7` work on a branch for bug fixing.

Still WIP. Contexts needs a deep copy of the known types.
If it's App, Device etc, we need to call `clone()` instead of just bringing the reference over.

This was done here: 

https://github.com/getsentry/sentry-dotnet-protocol/blob/afd65b92ed7122a628dc3631711b407f56e9a8a8/src/Sentry.Protocol/Context/Contexts.cs#L60