### PR TITLE
non-app is already inApp excluded by default.

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -40,11 +40,6 @@ final class AndroidOptionsInitializer {
     if (packageName != null && !packageName.startsWith("android.")) {
       options.addInAppInclude(packageName);
     }
-    options.addInAppExclude("android.");
-    options.addInAppExclude("com.android.");
-    options.addInAppExclude("androidx.");
-    options.addInAppExclude("kotlin.");
-    options.addInAppExclude("dalvik.");
   }
 
   private static void initializeCacheDirs(Context context, SentryOptions options) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -90,17 +90,6 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
-    fun `init should set android as inAppExclude`() {
-        val sentryOptions = SentryAndroidOptions()
-        val mockContext = createMockContext()
-        val mockLogger = mock<ILogger>()
-
-        AndroidOptionsInitializer.init(sentryOptions, mockContext, mockLogger)
-
-        assertTrue(sentryOptions.inAppExcludes.contains("android."))
-    }
-
-    @Test
     fun `init should set Android transport gate`() {
         val sentryOptions = SentryAndroidOptions()
         val mockContext = createMockContext()

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -34,8 +34,8 @@ public class SentryOptions {
   private @Nullable String environment;
   private @Nullable Proxy proxy;
   private @Nullable Double sampleRate;
-  private @NotNull List<String> inAppExcludes;
-  private @NotNull List<String> inAppIncludes;
+  private @NotNull List<String> inAppExcludes = new ArrayList<>();
+  private @NotNull List<String> inAppIncludes = new ArrayList<>();
   private @Nullable ITransport transport;
   private @Nullable ITransportGate transportGate;
   private @Nullable String dist;
@@ -211,9 +211,6 @@ public class SentryOptions {
   }
 
   public void addInAppExclude(@NotNull String exclude) {
-    if (inAppExcludes == null) {
-      inAppExcludes = new ArrayList<>();
-    }
     inAppExcludes.add(exclude);
   }
 
@@ -222,9 +219,6 @@ public class SentryOptions {
   }
 
   public void addInAppInclude(@NotNull String include) {
-    if (inAppIncludes == null) {
-      inAppIncludes = new ArrayList<>();
-    }
     inAppIncludes.add(include);
   }
 
@@ -263,18 +257,6 @@ public class SentryOptions {
   }
 
   public SentryOptions() {
-    inAppExcludes = new ArrayList<>();
-    inAppExcludes.add("io.sentry.");
-    inAppExcludes.add("java.");
-    inAppExcludes.add("javax.");
-    inAppExcludes.add("sun.");
-    inAppExcludes.add("com.oracle.");
-    inAppExcludes.add("oracle.");
-    inAppExcludes.add("org.jetbrains.");
-
-    inAppIncludes =
-        new ArrayList<>(); // make the list available so processor below can take the reference
-
     eventProcessors.add(new MainEventProcessor(this));
 
     // Start off sending any cached event.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
non-app is already inApp excluded by default.


## :bulb: Motivation and Context
we create a custom inApp included and excluded list, but by default non-app is included, so having it is pointless.


## :green_heart: How did you test it?
ran unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
