### PR TITLE
Refactor integrations to match unified API

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -25,9 +25,9 @@ final class AndroidOptionsInitializer {
     setDefaultInApp(context, options);
 
     // Integrations are registered in the same order. Watch outbox before adding NDK:
-    options.addIntegration(EnvelopeFileObserverIntegration.getOutboxFileObserver());
-    options.addIntegration(new NdkIntegration());
-    options.addIntegration(new AnrIntegration());
+    options.addDefaultIntegration(EnvelopeFileObserverIntegration.getOutboxFileObserver());
+    options.addDefaultIntegration(new NdkIntegration());
+    options.addDefaultIntegration(new AnrIntegration());
 
     options.addEventProcessor(new DefaultAndroidEventProcessor(context, options));
     options.setSerializer(new AndroidSerializer(options.getLogger()));

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -45,7 +45,7 @@ final class AnrIntegration implements Integration, Closeable {
   @TestOnly
   void reportANR(IHub hub, final @NotNull ILogger logger, ApplicationNotResponding error) {
     if (!hub.isIntegrationEnabled(AnrIntegration.class)) {
-      logger.log(SentryLevel.WARNING, "AnrIntegration is not enabled to the current hub.");
+      logger.log(SentryLevel.INFO, "AnrIntegration is not enabled for the current hub.");
       return;
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -44,6 +44,11 @@ final class AnrIntegration implements Integration, Closeable {
 
   @TestOnly
   void reportANR(IHub hub, final @NotNull ILogger logger, ApplicationNotResponding error) {
+    if (!hub.isIntegrationEnabled(AnrIntegration.class)) {
+      logger.log(SentryLevel.WARNING, "AnrIntegration is not enabled to the current hub.");
+      return;
+    }
+
     logger.log(SentryLevel.INFO, "ANR triggered with message: %s", error.getMessage());
 
     Mechanism mechanism = new Mechanism();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
@@ -2,6 +2,7 @@ package io.sentry.android.core;
 
 import android.os.FileObserver;
 import io.sentry.core.IEnvelopeSender;
+import io.sentry.core.IHub;
 import io.sentry.core.ILogger;
 import io.sentry.core.SentryLevel;
 import io.sentry.core.util.Objects;
@@ -14,19 +15,29 @@ final class EnvelopeFileObserver extends FileObserver {
   private final String rootPath;
   private final IEnvelopeSender envelopeSender;
   private @NotNull final ILogger logger;
+  private final @NotNull IHub hub;
 
   // The preferred overload (Taking File instead of String) is only available from API 29
   @SuppressWarnings("deprecation")
-  EnvelopeFileObserver(String path, IEnvelopeSender envelopeSender, @NotNull ILogger logger) {
+  EnvelopeFileObserver(
+      String path, IEnvelopeSender envelopeSender, @NotNull ILogger logger, @NotNull IHub hub) {
     super(path);
     this.rootPath = Objects.requireNonNull(path, "File path is required.");
     this.envelopeSender = Objects.requireNonNull(envelopeSender, "Envelope sender is required.");
     this.logger = Objects.requireNonNull(logger, "Logger is required.");
+    this.hub = Objects.requireNonNull(hub, "Hub is required.");
   }
 
   @Override
   public void onEvent(int eventType, @Nullable String relativePath) {
     if (relativePath == null || eventType != FileObserver.CLOSE_WRITE) {
+      return;
+    }
+
+    if (!hub.isIntegrationEnabled(EnvelopeFileObserverIntegration.class)) {
+      logger.log(
+          SentryLevel.WARNING,
+          "EnvelopeFileObserverIntegration is not enabled to the current hub.");
       return;
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
@@ -36,8 +36,7 @@ final class EnvelopeFileObserver extends FileObserver {
 
     if (!hub.isIntegrationEnabled(EnvelopeFileObserverIntegration.class)) {
       logger.log(
-          SentryLevel.WARNING,
-          "EnvelopeFileObserverIntegration is not enabled to the current hub.");
+          SentryLevel.INFO, "EnvelopeFileObserverIntegration is not enabled for the current hub.");
       return;
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
@@ -34,8 +34,7 @@ final class EnvelopeFileObserver extends FileObserver {
       return;
     }
 
-    if (!hub.isIntegrationEnabled(
-        EnvelopeFileObserverIntegration.OutboxEnvelopeFileObserverIntegration.class)) {
+    if (!hub.isIntegrationEnabled(EnvelopeFileObserverIntegration.class)) {
       logger.log(
           SentryLevel.WARNING,
           "EnvelopeFileObserverIntegration is not enabled to the current hub.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
@@ -34,7 +34,8 @@ final class EnvelopeFileObserver extends FileObserver {
       return;
     }
 
-    if (!hub.isIntegrationEnabled(EnvelopeFileObserverIntegration.class)) {
+    if (!hub.isIntegrationEnabled(
+        EnvelopeFileObserverIntegration.OutboxEnvelopeFileObserverIntegration.class)) {
       logger.log(
           SentryLevel.WARNING,
           "EnvelopeFileObserverIntegration is not enabled to the current hub.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -1,5 +1,6 @@
 package io.sentry.android.core;
 
+import io.sentry.core.EnvelopeReader;
 import io.sentry.core.EnvelopeSender;
 import io.sentry.core.IHub;
 import io.sentry.core.ILogger;
@@ -29,8 +30,7 @@ abstract class EnvelopeFileObserverIntegration implements Integration, Closeable
       logger.log(SentryLevel.DEBUG, "Registering CachedEventReaderIntegration for path: %s", path);
 
       EnvelopeSender envelopeSender =
-          new EnvelopeSender(
-              hub, new io.sentry.core.EnvelopeReader(), options.getSerializer(), logger);
+          new EnvelopeSender(hub, new EnvelopeReader(), options.getSerializer(), logger);
 
       observer = new EnvelopeFileObserver(path, envelopeSender, logger);
       observer.startWatching();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -32,7 +32,7 @@ abstract class EnvelopeFileObserverIntegration implements Integration, Closeable
       EnvelopeSender envelopeSender =
           new EnvelopeSender(hub, new EnvelopeReader(), options.getSerializer(), logger);
 
-      observer = new EnvelopeFileObserver(path, envelopeSender, logger);
+      observer = new EnvelopeFileObserver(path, envelopeSender, logger, hub);
       observer.startWatching();
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -47,8 +47,7 @@ abstract class EnvelopeFileObserverIntegration implements Integration, Closeable
   @TestOnly
   abstract String getPath(SentryOptions options);
 
-  private static final class OutboxEnvelopeFileObserverIntegration
-      extends EnvelopeFileObserverIntegration {
+  static final class OutboxEnvelopeFileObserverIntegration extends EnvelopeFileObserverIntegration {
     @Override
     protected String getPath(final SentryOptions options) {
       return options.getOutboxPath();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -47,7 +47,8 @@ abstract class EnvelopeFileObserverIntegration implements Integration, Closeable
   @TestOnly
   abstract String getPath(SentryOptions options);
 
-  static final class OutboxEnvelopeFileObserverIntegration extends EnvelopeFileObserverIntegration {
+  private static final class OutboxEnvelopeFileObserverIntegration
+      extends EnvelopeFileObserverIntegration {
     @Override
     protected String getPath(final SentryOptions options) {
       return options.getOutboxPath();

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
@@ -1,8 +1,10 @@
 package io.sentry.android.core
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.IHub
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -42,6 +44,10 @@ class AnrIntegrationTest {
     @Test
     fun `When ANR watch dog is triggered, it should capture exception`() {
         val hub = mock<IHub>()
+
+        whenever(hub.isIntegrationEnabled(eq(AnrIntegration::class.java)))
+            .thenReturn(true)
+
         val integration = AnrIntegration()
         integration.reportANR(hub, mock(), mock())
         verify(hub).captureException(any())

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.sentry.core.Hub
+import io.sentry.core.HubAdapter
 import io.sentry.core.SentryOptions
 import java.io.File
 import java.nio.file.Files
@@ -45,8 +46,9 @@ class EnvelopeFileObserverIntegrationTest {
         options.cacheDirPath = file.absolutePath
         options.addIntegration(integrationMock)
         options.setSerializer(mock())
+        val expected = HubAdapter.getInstance()
         val hub = Hub(options)
-        verify(integrationMock).register(hub, options)
+        verify(integrationMock).register(expected, options)
         hub.close()
         verify(integrationMock).close()
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -44,7 +44,7 @@ class EnvelopeFileObserverIntegrationTest {
         val options = SentryOptions()
         options.dsn = "https://key@sentry.io/proj"
         options.cacheDirPath = file.absolutePath
-        options.addDefaultIntegration(integrationMock)
+        options.addIntegration(integrationMock)
         options.setSerializer(mock())
         val expected = HubAdapter.getInstance()
         val hub = Hub(options)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -44,7 +44,7 @@ class EnvelopeFileObserverIntegrationTest {
         val options = SentryOptions()
         options.dsn = "https://key@sentry.io/proj"
         options.cacheDirPath = file.absolutePath
-        options.addIntegration(integrationMock)
+        options.addDefaultIntegration(integrationMock)
         options.setSerializer(mock())
         val expected = HubAdapter.getInstance()
         val hub = Hub(options)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverTest.kt
@@ -3,11 +3,14 @@ package io.sentry.android.core
 import android.os.FileObserver
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.IEnvelopeSender
+import io.sentry.core.IHub
 import io.sentry.core.ILogger
 import io.sentry.core.SentryOptions
 import java.io.File
@@ -23,6 +26,7 @@ class EnvelopeFileObserverTest {
         var path: String? = "."
         var envelopeSender: IEnvelopeSender = mock()
         var logger: ILogger = mock()
+        var hub: IHub = mock()
 
         init {
             val options = SentryOptions()
@@ -31,7 +35,7 @@ class EnvelopeFileObserverTest {
         }
 
         fun getSut(): EnvelopeFileObserver {
-            return EnvelopeFileObserver(path, envelopeSender, logger)
+            return EnvelopeFileObserver(path, envelopeSender, logger, hub)
         }
     }
 
@@ -41,6 +45,10 @@ class EnvelopeFileObserverTest {
     fun `envelope sender is called with fully qualified path`() {
         val sut = fixture.getSut()
         val param = "file-name.txt"
+
+        whenever(fixture.hub.isIntegrationEnabled(eq(EnvelopeFileObserverIntegration::class.java)))
+            .thenReturn(true)
+
         sut.onEvent(FileObserver.CLOSE_WRITE, param)
         verify(fixture.envelopeSender).processEnvelopeFile(fixture.path + File.separator + param)
     }

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -36,7 +36,7 @@ public final class Hub implements IHub {
     // Register integrations against the current hub at the given time
     // Default integrations should run only once
     if (ranDefaultIntegrations.getAndSet(true)) {
-      if (options.isEnableDefaultIntegrations()) {
+      if (options.isDefaultIntegrationsEnabled()) {
         for (Integration integration : options.getDefaultIntegrations()) {
           integration.register(HubAdapter.getInstance(), options);
         }
@@ -175,7 +175,7 @@ public final class Hub implements IHub {
           .log(SentryLevel.WARNING, "Instance is disabled and this 'close' call is a no-op.");
     } else {
       try {
-        if (options.isEnableDefaultIntegrations()) {
+        if (options.isDefaultIntegrationsEnabled()) {
           for (Integration integration : options.getDefaultIntegrations()) {
             if (integration instanceof Closeable) {
               ((Closeable) integration).close();
@@ -505,8 +505,12 @@ public final class Hub implements IHub {
     return clone;
   }
 
-  @Override
-  public ISentryClient getSentryClient() {
+  /**
+   * Returns the client bound to this hub
+   *
+   * @return the ISentryClient object
+   */
+  private ISentryClient getSentryClient() {
     ISentryClient sentryClient = NoOpSentryClient.getInstance();
     if (!isEnabled()) {
       options

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -30,9 +30,9 @@ public final class Hub implements IHub {
   public Hub(@NotNull SentryOptions options) {
     this(options, createRootStackItem(options));
 
-    // Register integrations against a root Hub
+    // Register integrations against the current hub at the given time
     for (Integration integration : options.getIntegrations()) {
-      integration.register(this, options);
+      integration.register(HubAdapter.getInstance(), options);
     }
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -510,4 +510,9 @@ public final class Hub implements IHub {
     }
     return sentryClient;
   }
+
+  @Override
+  public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
+    return getSentryClient().isIntegrationEnabled(integration);
+  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -484,4 +484,30 @@ public final class Hub implements IHub {
     }
     return clone;
   }
+
+  @Override
+  public ISentryClient getSentryClient() {
+    ISentryClient sentryClient = NoOpSentryClient.getInstance();
+    if (!isEnabled()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.WARNING,
+              "Instance is disabled and this 'getSentryClient' call is a no-op.");
+    } else {
+      try {
+        StackItem item = stack.peek();
+        if (item != null) {
+          sentryClient = item.client;
+        } else {
+          options.getLogger().log(SentryLevel.FATAL, "Stack peek was null when getSentryClient");
+        }
+      } catch (Exception e) {
+        options
+            .getLogger()
+            .log(SentryLevel.ERROR, "Error while getSentryClient: " + e.getMessage(), e);
+      }
+    }
+    return sentryClient;
+  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
@@ -124,4 +124,9 @@ public final class HubAdapter implements IHub {
   public ISentryClient getSentryClient() {
     return Sentry.getCurrentHub().getSentryClient();
   }
+
+  @Override
+  public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
+    return Sentry.getCurrentHub().isIntegrationEnabled(integration);
+  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
@@ -119,4 +119,9 @@ public final class HubAdapter implements IHub {
   public IHub clone() {
     return Sentry.getCurrentHub().clone();
   }
+
+  @Override
+  public ISentryClient getSentryClient() {
+    return Sentry.getCurrentHub().getSentryClient();
+  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
@@ -76,8 +76,18 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
+  public void removeTag(String key) {
+    Sentry.removeTag(key);
+  }
+
+  @Override
   public void setExtra(String key, String value) {
     Sentry.setExtra(key, value);
+  }
+
+  @Override
+  public void removeExtra(String key) {
+    Sentry.removeExtra(key);
   }
 
   @Override

--- a/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
@@ -1,0 +1,122 @@
+package io.sentry.core;
+
+import io.sentry.core.protocol.SentryId;
+import io.sentry.core.protocol.User;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+
+public final class HubAdapter implements IHub {
+
+  private static final HubAdapter INSTANCE = new HubAdapter();
+
+  private HubAdapter() {}
+
+  public static HubAdapter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return Sentry.isEnabled();
+  }
+
+  @Override
+  public SentryId captureEvent(SentryEvent event, @Nullable Object hint) {
+    return Sentry.captureEvent(event, hint);
+  }
+
+  @Override
+  public SentryId captureMessage(String message, SentryLevel level) {
+    return Sentry.captureMessage(message, level);
+  }
+
+  @Override
+  public SentryId captureException(Throwable throwable, @Nullable Object hint) {
+    return Sentry.captureException(throwable, hint);
+  }
+
+  @Override
+  public void close() {
+    Sentry.close();
+  }
+
+  @Override
+  public void addBreadcrumb(Breadcrumb breadcrumb, @Nullable Object hint) {
+    Sentry.addBreadcrumb(breadcrumb, hint);
+  }
+
+  @Override
+  public void setLevel(SentryLevel level) {
+    Sentry.setLevel(level);
+  }
+
+  @Override
+  public void setTransaction(String transaction) {
+    Sentry.setTransaction(transaction);
+  }
+
+  @Override
+  public void setUser(User user) {
+    Sentry.setUser(user);
+  }
+
+  @Override
+  public void setFingerprint(List<String> fingerprint) {
+    Sentry.setFingerprint(fingerprint);
+  }
+
+  @Override
+  public void clearBreadcrumbs() {
+    Sentry.clearBreadcrumbs();
+  }
+
+  @Override
+  public void setTag(String key, String value) {
+    Sentry.setTag(key, value);
+  }
+
+  @Override
+  public void setExtra(String key, String value) {
+    Sentry.setExtra(key, value);
+  }
+
+  @Override
+  public SentryId getLastEventId() {
+    return Sentry.getLastEventId();
+  }
+
+  @Override
+  public void pushScope() {
+    Sentry.pushScope();
+  }
+
+  @Override
+  public void popScope() {
+    Sentry.popScope();
+  }
+
+  @Override
+  public void withScope(ScopeCallback callback) {
+    Sentry.withScope(callback);
+  }
+
+  @Override
+  public void configureScope(ScopeCallback callback) {
+    Sentry.configureScope(callback);
+  }
+
+  @Override
+  public void bindClient(ISentryClient client) {
+    Sentry.bindClient(client);
+  }
+
+  @Override
+  public void flush(long timeoutMills) {
+    Sentry.flush(timeoutMills);
+  }
+
+  @Override
+  public IHub clone() {
+    return Sentry.getCurrentHub().clone();
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
@@ -121,11 +121,6 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public ISentryClient getSentryClient() {
-    return Sentry.getCurrentHub().getSentryClient();
-  }
-
-  @Override
   public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
     return Sentry.getCurrentHub().isIntegrationEnabled(integration);
   }

--- a/sentry-core/src/main/java/io/sentry/core/IHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/IHub.java
@@ -212,13 +212,6 @@ public interface IHub {
   IHub clone();
 
   /**
-   * Returns the client bound to this hub
-   *
-   * @return the ISentryClient object
-   */
-  ISentryClient getSentryClient();
-
-  /**
    * Check if the given integration is enabled to this hub
    *
    * @param integration the Integration class

--- a/sentry-core/src/main/java/io/sentry/core/IHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/IHub.java
@@ -210,4 +210,11 @@ public interface IHub {
    * @return the cloned Hub
    */
   IHub clone();
+
+  /**
+   * Returns the client bound to this hub
+   *
+   * @return the ISentryClient object
+   */
+  ISentryClient getSentryClient();
 }

--- a/sentry-core/src/main/java/io/sentry/core/IHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/IHub.java
@@ -217,4 +217,13 @@ public interface IHub {
    * @return the ISentryClient object
    */
   ISentryClient getSentryClient();
+
+  /**
+   * Check if the given integration is enabled to this hub
+   *
+   * @param integration the Integration class
+   * @param <T> a class that implements Integration
+   * @return true if enabled or false otherwise
+   */
+  <T extends Integration> boolean isIntegrationEnabled(Class<T> integration);
 }

--- a/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
@@ -140,4 +140,11 @@ public interface ISentryClient {
   default SentryId captureException(Throwable throwable, @Nullable Scope scope) {
     return captureException(throwable, scope, null);
   }
+
+  /**
+   * Returns the SentryOptions bound to this client
+   *
+   * @return the SentryOptions object
+   */
+  SentryOptions getSentryOptions();
 }

--- a/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/ISentryClient.java
@@ -142,9 +142,11 @@ public interface ISentryClient {
   }
 
   /**
-   * Returns the SentryOptions bound to this client
+   * Check if the given integration is enabled to this client
    *
-   * @return the SentryOptions object
+   * @param integration the Integration class
+   * @param <T> a class that implements Integration
+   * @return true if enabled or false otherwise
    */
-  SentryOptions getSentryOptions();
+  <T extends Integration> boolean isIntegrationEnabled(Class<T> integration);
 }

--- a/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
@@ -89,4 +89,9 @@ final class NoOpHub implements IHub {
   public IHub clone() {
     return instance;
   }
+
+  @Override
+  public ISentryClient getSentryClient() {
+    return NoOpSentryClient.getInstance();
+  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
@@ -94,4 +94,9 @@ final class NoOpHub implements IHub {
   public ISentryClient getSentryClient() {
     return NoOpSentryClient.getInstance();
   }
+
+  @Override
+  public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
+    return false;
+  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpHub.java
@@ -91,11 +91,6 @@ final class NoOpHub implements IHub {
   }
 
   @Override
-  public ISentryClient getSentryClient() {
-    return NoOpSentryClient.getInstance();
-  }
-
-  @Override
   public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
     return false;
   }

--- a/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
@@ -28,4 +28,9 @@ final class NoOpSentryClient implements ISentryClient {
 
   @Override
   public void flush(long timeoutMills) {}
+
+  @Override
+  public SentryOptions getSentryOptions() {
+    return new SentryOptions();
+  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
@@ -33,9 +33,4 @@ final class NoOpSentryClient implements ISentryClient {
   public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
     return false;
   }
-
-  //  @Override
-  //  public SentryOptions getSentryOptions() {
-  //    return new SentryOptions();
-  //  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpSentryClient.java
@@ -30,7 +30,12 @@ final class NoOpSentryClient implements ISentryClient {
   public void flush(long timeoutMills) {}
 
   @Override
-  public SentryOptions getSentryOptions() {
-    return new SentryOptions();
+  public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
+    return false;
   }
+
+  //  @Override
+  //  public SentryOptions getSentryOptions() {
+  //    return new SentryOptions();
+  //  }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
@@ -39,8 +39,8 @@ final class SendCachedEventFireAndForgetIntegration implements Integration {
               options
                   .getLogger()
                   .log(
-                      SentryLevel.WARNING,
-                      "SendCachedEventFireAndForgetIntegration is not enabled to the current hub.");
+                      SentryLevel.INFO,
+                      "SendCachedEventFireAndForgetIntegration is not enabled for the current hub.");
               return;
             }
 

--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
@@ -35,6 +35,17 @@ final class SendCachedEventFireAndForgetIntegration implements Integration {
       ExecutorService es = Executors.newSingleThreadExecutor();
       es.submit(
           () -> {
+            // we have 2 instances of type SendCachedEventFireAndForgetIntegration
+            // we might need to use .equals instead of instanceOf
+            if (!hub.isIntegrationEnabled(SendCachedEventFireAndForgetIntegration.class)) {
+              options
+                  .getLogger()
+                  .log(
+                      SentryLevel.WARNING,
+                      "SendCachedEventFireAndForgetIntegration is not enabled to the current hub.");
+              return;
+            }
+
             try {
               sender.send();
               options

--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
@@ -35,8 +35,6 @@ final class SendCachedEventFireAndForgetIntegration implements Integration {
       ExecutorService es = Executors.newSingleThreadExecutor();
       es.submit(
           () -> {
-            // we have 2 instances of type SendCachedEventFireAndForgetIntegration
-            // we might need to use .equals instead of instanceOf
             if (!hub.isIntegrationEnabled(SendCachedEventFireAndForgetIntegration.class)) {
               options
                   .getLogger()

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -280,7 +280,7 @@ public final class Sentry {
    *
    * @param key the key
    */
-  public void removeExtra(@NotNull String key) {
+  public static void removeExtra(@NotNull String key) {
     getCurrentHub().removeExtra(key);
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -21,7 +21,7 @@ public final class Sentry {
    *
    * @return the hub
    */
-  private static @NotNull IHub getCurrentHub() {
+  static @NotNull IHub getCurrentHub() {
     IHub hub = currentHub.get();
     if (hub == null) {
       currentHub.set(mainHub.clone());
@@ -317,7 +317,7 @@ public final class Sentry {
    *
    * @param timeoutMills time in milliseconds
    */
-  public static void flush(int timeoutMills) {
+  public static void flush(long timeoutMills) {
     getCurrentHub().flush(timeoutMills);
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -21,7 +21,7 @@ public final class Sentry {
    *
    * @return the hub
    */
-  static @NotNull IHub getCurrentHub() {
+  public static @NotNull IHub getCurrentHub() {
     IHub hub = currentHub.get();
     if (hub == null) {
       currentHub.set(mainHub.clone());

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -234,11 +234,6 @@ public final class SentryClient implements ISentryClient {
     return false;
   }
 
-  //  @Override
-  //  public SentryOptions getSentryOptions() {
-  //    return options;
-  //  }
-
   private boolean sample() {
     // https://docs.sentry.io/development/sdk-dev/features/#event-sampling
     if (options.getSampleRate() != null && random != null) {

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -223,6 +223,11 @@ public final class SentryClient implements ISentryClient {
     // TODO: Flush transport
   }
 
+  @Override
+  public SentryOptions getSentryOptions() {
+    return options;
+  }
+
   private boolean sample() {
     // https://docs.sentry.io/development/sdk-dev/features/#event-sampling
     if (options.getSampleRate() != null && random != null) {

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -225,6 +225,12 @@ public final class SentryClient implements ISentryClient {
 
   @Override
   public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
+    for (Integration item : options.getDefaultIntegrations()) {
+      if (integration.isInstance(item)) {
+        return true;
+      }
+    }
+
     for (Integration item : options.getIntegrations()) {
       if (integration.isInstance(item)) {
         return true;

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -224,9 +224,20 @@ public final class SentryClient implements ISentryClient {
   }
 
   @Override
-  public SentryOptions getSentryOptions() {
-    return options;
+  public <T extends Integration> boolean isIntegrationEnabled(Class<T> integration) {
+    for (Integration item : options.getIntegrations()) {
+      if (integration.isInstance(item)) {
+        return true;
+      }
+    }
+
+    return false;
   }
+
+  //  @Override
+  //  public SentryOptions getSentryOptions() {
+  //    return options;
+  //  }
 
   private boolean sample() {
     // https://docs.sentry.io/development/sdk-dev/features/#event-sampling

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -16,6 +16,7 @@ public class SentryOptions {
 
   private final @NotNull List<EventProcessor> eventProcessors = new ArrayList<>();
   private final @NotNull List<Integration> integrations = new ArrayList<>();
+  private final @NotNull List<Integration> defaultIntegrations = new ArrayList<>();
 
   private @Nullable String dsn;
   private long shutdownTimeoutMills = 2000; // default 2s
@@ -39,7 +40,7 @@ public class SentryOptions {
   private @Nullable ITransport transport;
   private @Nullable ITransportGate transportGate;
   private @Nullable String dist;
-  private boolean defaultIntegrations = true;
+  private boolean enableDefaultIntegrations = true;
 
   public void addEventProcessor(@NotNull EventProcessor eventProcessor) {
     eventProcessors.add(eventProcessor);
@@ -53,8 +54,17 @@ public class SentryOptions {
     integrations.add(integration);
   }
 
+  public void addDefaultIntegration(@NotNull Integration integration) {
+    defaultIntegrations.add(integration);
+  }
+
   public @NotNull List<Integration> getIntegrations() {
     return integrations;
+  }
+
+  @NotNull
+  List<Integration> getDefaultIntegrations() {
+    return defaultIntegrations;
   }
 
   public @Nullable String getDsn() {
@@ -253,12 +263,12 @@ public class SentryOptions {
     this.transportGate = transportGate;
   }
 
-  public boolean isDefaultIntegrations() {
-    return defaultIntegrations;
+  public boolean isEnableDefaultIntegrations() {
+    return enableDefaultIntegrations;
   }
 
-  public void setDefaultIntegrations(boolean defaultIntegrations) {
-    this.defaultIntegrations = defaultIntegrations;
+  public void setEnableDefaultIntegrations(boolean enableDefaultIntegrations) {
+    this.enableDefaultIntegrations = enableDefaultIntegrations;
   }
 
   public interface BeforeSendCallback {
@@ -287,7 +297,7 @@ public class SentryOptions {
     eventProcessors.add(new MainEventProcessor(this));
 
     // Start off sending any cached event.
-    integrations.add(
+    defaultIntegrations.add(
         new SendCachedEventFireAndForgetIntegration(
             (hub, options) -> {
               SendCachedEvent sender =
@@ -305,7 +315,7 @@ public class SentryOptions {
               }
             }));
     // Send cache envelopes from NDK
-    integrations.add(
+    defaultIntegrations.add(
         new SendCachedEventFireAndForgetIntegration(
             (hub, options) -> {
               EnvelopeSender envelopeSender =
@@ -322,6 +332,6 @@ public class SentryOptions {
                 return null;
               }
             }));
-    integrations.add(new UncaughtExceptionHandlerIntegration());
+    defaultIntegrations.add(new UncaughtExceptionHandlerIntegration());
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -39,6 +39,7 @@ public class SentryOptions {
   private @Nullable ITransport transport;
   private @Nullable ITransportGate transportGate;
   private @Nullable String dist;
+  private boolean defaultIntegrations = true;
 
   public void addEventProcessor(@NotNull EventProcessor eventProcessor) {
     eventProcessors.add(eventProcessor);
@@ -252,6 +253,14 @@ public class SentryOptions {
     this.transportGate = transportGate;
   }
 
+  public boolean isDefaultIntegrations() {
+    return defaultIntegrations;
+  }
+
+  public void setDefaultIntegrations(boolean defaultIntegrations) {
+    this.defaultIntegrations = defaultIntegrations;
+  }
+
   public interface BeforeSendCallback {
     @Nullable
     SentryEvent execute(@NotNull SentryEvent event, @Nullable Object hint);
@@ -300,8 +309,7 @@ public class SentryOptions {
         new SendCachedEventFireAndForgetIntegration(
             (hub, options) -> {
               EnvelopeSender envelopeSender =
-                  new EnvelopeSender(
-                      hub, new io.sentry.core.EnvelopeReader(), options.getSerializer(), logger);
+                  new EnvelopeSender(hub, new EnvelopeReader(), options.getSerializer(), logger);
               if (options.getOutboxPath() != null) {
                 File outbox = new File(options.getOutboxPath());
                 return () -> envelopeSender.processDirectory(outbox);

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -40,7 +40,7 @@ public class SentryOptions {
   private @Nullable ITransport transport;
   private @Nullable ITransportGate transportGate;
   private @Nullable String dist;
-  private boolean enableDefaultIntegrations = true;
+  private boolean defaultIntegrationsEnabled = true;
 
   public void addEventProcessor(@NotNull EventProcessor eventProcessor) {
     eventProcessors.add(eventProcessor);
@@ -263,12 +263,12 @@ public class SentryOptions {
     this.transportGate = transportGate;
   }
 
-  public boolean isEnableDefaultIntegrations() {
-    return enableDefaultIntegrations;
+  public boolean isDefaultIntegrationsEnabled() {
+    return defaultIntegrationsEnabled;
   }
 
-  public void setEnableDefaultIntegrations(boolean enableDefaultIntegrations) {
-    this.enableDefaultIntegrations = enableDefaultIntegrations;
+  public void setDefaultIntegrationsEnabled(boolean defaultIntegrationsEnabled) {
+    this.defaultIntegrationsEnabled = defaultIntegrationsEnabled;
   }
 
   public interface BeforeSendCallback {

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -71,8 +71,8 @@ final class UncaughtExceptionHandlerIntegration
       options
           .getLogger()
           .log(
-              SentryLevel.WARNING,
-              "UncaughtExceptionHandlerIntegration is not enabled to the current hub.");
+              SentryLevel.INFO,
+              "UncaughtExceptionHandlerIntegration is not enabled for the current hub.");
       return;
     }
 

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -67,6 +67,15 @@ final class UncaughtExceptionHandlerIntegration
 
   @Override
   public void uncaughtException(Thread thread, Throwable thrown) {
+    if (!hub.isIntegrationEnabled(UncaughtExceptionHandlerIntegration.class)) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.WARNING,
+              "UncaughtExceptionHandlerIntegration is not enabled to the current hub.");
+      return;
+    }
+
     options.getLogger().log(SentryLevel.INFO, "Uncaught exception received.");
 
     try {

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -50,7 +50,7 @@ class HubTest {
         options.cacheDirPath = file.absolutePath
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
-        options.addDefaultIntegration(integrationMock)
+        options.addIntegration(integrationMock)
         Hub(options)
         val expected = HubAdapter.getInstance()
         verify(integrationMock).register(expected, options)
@@ -63,7 +63,7 @@ class HubTest {
         options.cacheDirPath = file.absolutePath
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
-        options.addDefaultIntegration(integrationMock)
+        options.addIntegration(integrationMock)
         val hub = Hub(options)
         val expected = HubAdapter.getInstance()
         verify(integrationMock).register(expected, options)
@@ -517,7 +517,7 @@ class HubTest {
         var options: SentryOptions? = null
         // init main hub and make it enabled
         Sentry.init {
-            it.addDefaultIntegration(mock)
+            it.addIntegration(mock)
             it.dsn = "https://key@sentry.io/proj"
             it.cacheDirPath = file.absolutePath
             it.setSerializer(mock())

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -50,7 +50,7 @@ class HubTest {
         options.cacheDirPath = file.absolutePath
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
-        options.addIntegration(integrationMock)
+        options.addDefaultIntegration(integrationMock)
         Hub(options)
         val expected = HubAdapter.getInstance()
         verify(integrationMock).register(expected, options)
@@ -63,7 +63,7 @@ class HubTest {
         options.cacheDirPath = file.absolutePath
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
-        options.addIntegration(integrationMock)
+        options.addDefaultIntegration(integrationMock)
         val hub = Hub(options)
         val expected = HubAdapter.getInstance()
         verify(integrationMock).register(expected, options)
@@ -517,7 +517,7 @@ class HubTest {
         var options: SentryOptions? = null
         // init main hub and make it enabled
         Sentry.init {
-            it.addIntegration(mock)
+            it.addDefaultIntegration(mock)
             it.dsn = "https://key@sentry.io/proj"
             it.cacheDirPath = file.absolutePath
             it.setSerializer(mock())

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -34,6 +34,7 @@ class HubTest {
     @AfterTest
     fun shutdown() {
         Files.delete(file.toPath())
+        Sentry.close()
     }
 
     @Test
@@ -50,7 +51,8 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         options.addIntegration(integrationMock)
-        val expected = Hub(options)
+        Hub(options)
+        val expected = HubAdapter.getInstance()
         verify(integrationMock).register(expected, options)
     }
 
@@ -62,9 +64,10 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         options.addIntegration(integrationMock)
-        val expected = Hub(options)
+        val hub = Hub(options)
+        val expected = HubAdapter.getInstance()
         verify(integrationMock).register(expected, options)
-        expected.clone()
+        hub.clone()
         verifyNoMoreInteractions(integrationMock)
     }
 
@@ -510,17 +513,22 @@ class HubTest {
     @Test
     fun `when integration is registered, hub is enabled`() {
         val mock = mock<Integration>()
-        val options = SentryOptions().apply {
-            addIntegration(mock)
-            dsn = "https://key@sentry.io/proj"
-            cacheDirPath = file.absolutePath
-            setSerializer(mock())
+
+        var options: SentryOptions? = null
+        // init main hub and make it enabled
+        Sentry.init {
+            it.addIntegration(mock)
+            it.dsn = "https://key@sentry.io/proj"
+            it.cacheDirPath = file.absolutePath
+            it.setSerializer(mock())
+            options = it
         }
+
         doAnswer {
             val hub = it.arguments[0] as IHub
             assertTrue(hub.isEnabled)
         }.whenever(mock).register(any(), eq(options))
-        Hub(options)
+
         verify(mock).register(any(), eq(options))
     }
 

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -41,7 +41,7 @@ class SentryOptionsTest {
 
     @Test
     fun `when options is initialized, integrations contain UncaughtExceptionHandlerIntegration`() {
-        assertTrue(SentryOptions().integrations.any { it is UncaughtExceptionHandlerIntegration })
+        assertTrue(SentryOptions().defaultIntegrations.any { it is UncaughtExceptionHandlerIntegration })
     }
 
     @Test

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -92,8 +92,9 @@ class UncaughtExceptionHandlerIntegrationTest {
         options.addIntegration(integrationMock)
         options.cacheDirPath = file.absolutePath
         options.setSerializer(mock())
+        val expected = HubAdapter.getInstance()
         val hub = Hub(options)
-        verify(integrationMock).register(hub, options)
+        verify(integrationMock).register(expected, options)
         hub.close()
         verify(integrationMock).close()
     }

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -102,7 +102,7 @@ class UncaughtExceptionHandlerIntegrationTest {
         val integrationMock = mock<UncaughtExceptionHandlerIntegration>()
         val options = SentryOptions()
         options.dsn = "https://key@sentry.io/proj"
-        options.addDefaultIntegration(integrationMock)
+        options.addIntegration(integrationMock)
         options.cacheDirPath = file.absolutePath
         options.setSerializer(mock())
         val expected = HubAdapter.getInstance()

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.core
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -42,6 +43,10 @@ class UncaughtExceptionHandlerIntegrationTest {
         val threadMock = mock<Thread>()
         val throwableMock = mock<Throwable>()
         val hubMock = mock<IHub>()
+
+        whenever(hubMock.isIntegrationEnabled(eq(UncaughtExceptionHandlerIntegration::class.java)))
+            .thenReturn(true)
+
         val options = SentryOptions()
         val sut = UncaughtExceptionHandlerIntegration(handlerMock)
         sut.register(hubMock, options)
@@ -57,6 +62,10 @@ class UncaughtExceptionHandlerIntegrationTest {
         val defaultHandlerMock = mock<Thread.UncaughtExceptionHandler>()
         whenever(handlerMock.defaultUncaughtExceptionHandler).thenReturn(defaultHandlerMock)
         val hubMock = mock<IHub>()
+
+        whenever(hubMock.isIntegrationEnabled(eq(UncaughtExceptionHandlerIntegration::class.java)))
+            .thenReturn(true)
+
         val options = SentryOptions()
         val sut = UncaughtExceptionHandlerIntegration(handlerMock)
         sut.register(hubMock, options)
@@ -70,6 +79,10 @@ class UncaughtExceptionHandlerIntegrationTest {
         val threadMock = mock<Thread>()
         val throwableMock = mock<Throwable>()
         val hubMock = mock<IHub>()
+
+        whenever(hubMock.isIntegrationEnabled(eq(UncaughtExceptionHandlerIntegration::class.java)))
+            .thenReturn(true)
+
         whenever(hubMock.captureException(any())).thenAnswer { invocation ->
             val e = (invocation.arguments[1] as ExceptionMechanismException)
             assertNotNull(e)

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -102,7 +102,7 @@ class UncaughtExceptionHandlerIntegrationTest {
         val integrationMock = mock<UncaughtExceptionHandlerIntegration>()
         val options = SentryOptions()
         options.dsn = "https://key@sentry.io/proj"
-        options.addIntegration(integrationMock)
+        options.addDefaultIntegration(integrationMock)
         options.cacheDirPath = file.absolutePath
         options.setSerializer(mock())
         val expected = HubAdapter.getInstance()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
Refactor integrations to match unified API.


## :bulb: Motivation and Context
Integrations should use always the current hub.
Default integrations should have an opt-out flag.
Default integrations should run only once.

## :green_heart: How did you test it?
not yet, I'll write unit tests for everything, this is just a draft as a POC

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
write unit tests, convert EventProcessors to Integrations