### PR TITLE
feat: Hub mode configurable

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -56,13 +56,13 @@ public final class SentryAndroid {
       @NotNull ILogger logger,
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration) {
     try {
-      Sentry.setGlobalHubMode(true);
       Sentry.init(
           OptionsContainer.create(SentryAndroidOptions.class),
           options -> {
             AndroidOptionsInitializer.init(options, context, logger);
             configuration.configure(options);
-          });
+          },
+          true);
     } catch (IllegalAccessException e) {
       logger.log(SentryLevel.FATAL, "Fatal error during SentryAndroid.init(...)", e);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -56,6 +56,7 @@ public final class SentryAndroid {
       @NotNull ILogger logger,
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration) {
     try {
+      Sentry.setGlobalHubMode(true);
       Sentry.init(
           OptionsContainer.create(SentryAndroidOptions.class),
           options -> {

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -12,10 +12,17 @@ public final class Sentry {
 
   private Sentry() {}
 
+  /** Holds Hubs per thread or only mainHub if globalHubMode is enabled. */
   private static final @NotNull ThreadLocal<IHub> currentHub = new ThreadLocal<>();
 
+  /** The Main Hub or NoOp if Sentry is disabled. */
   private static volatile @NotNull IHub mainHub = NoOpHub.getInstance();
-  private static volatile boolean isGlobalHubMode = false;
+
+  /** Default value for globalHubMode is false */
+  private static final boolean GLOBAL_HUB_DEFAULT_MODE = false;
+
+  /** whether to use a single (global) Hub as opposed to one per thread. */
+  private static volatile boolean globalHubMode = GLOBAL_HUB_DEFAULT_MODE;
 
   /**
    * Returns the current (threads) hub, if none, clones the mainHub and returns it.
@@ -23,7 +30,7 @@ public final class Sentry {
    * @return the hub
    */
   private static @NotNull IHub getCurrentHub() {
-    if (isGlobalHubMode) {
+    if (globalHubMode) {
       return mainHub;
     }
     IHub hub = currentHub.get();
@@ -31,11 +38,6 @@ public final class Sentry {
       currentHub.set(mainHub.clone());
     }
     return currentHub.get();
-  }
-
-  /** Sets whether to use a single (global) Hub as opposed to one per thread. */
-  public static void setGlobalHubMode(boolean useGlobalHubMode) {
-    isGlobalHubMode = useGlobalHubMode;
   }
 
   /**
@@ -49,7 +51,7 @@ public final class Sentry {
 
   /** Initializes the SDK */
   public static void init() {
-    init(new SentryOptions());
+    init(new SentryOptions(), GLOBAL_HUB_DEFAULT_MODE);
   }
 
   /**
@@ -65,9 +67,28 @@ public final class Sentry {
       @NotNull OptionsContainer<T> clazz, @NotNull OptionsConfiguration<T> optionsConfiguration)
       throws IllegalAccessException, InstantiationException, NoSuchMethodException,
           InvocationTargetException {
+    init(clazz, optionsConfiguration, GLOBAL_HUB_DEFAULT_MODE);
+  }
+
+  /**
+   * @param clazz OptionsContainer for SentryOptions
+   * @param optionsConfiguration configuration options callback
+   * @param globalHubMode the globalHubMode
+   * @param <T> class that extends SentryOptions
+   * @throws IllegalAccessException the IllegalAccessException
+   * @throws InstantiationException the InstantiationException
+   * @throws NoSuchMethodException the NoSuchMethodException
+   * @throws InvocationTargetException the InvocationTargetException
+   */
+  public static <T extends SentryOptions> void init(
+      @NotNull OptionsContainer<T> clazz,
+      @NotNull OptionsConfiguration<T> optionsConfiguration,
+      boolean globalHubMode)
+      throws IllegalAccessException, InstantiationException, NoSuchMethodException,
+          InvocationTargetException {
     T options = clazz.createInstance();
     optionsConfiguration.configure(options);
-    init(options);
+    init(options, globalHubMode);
   }
 
   /**
@@ -76,12 +97,31 @@ public final class Sentry {
    * @param optionsConfiguration configuration options callback
    */
   public static void init(@NotNull OptionsConfiguration<SentryOptions> optionsConfiguration) {
-    SentryOptions options = new SentryOptions();
-    optionsConfiguration.configure(options);
-    init(options);
+    init(optionsConfiguration, GLOBAL_HUB_DEFAULT_MODE);
   }
 
-  private static synchronized <T extends SentryOptions> void init(@NotNull T options) {
+  /**
+   * Initializes the SDK with an optional configuration options callback.
+   *
+   * @param optionsConfiguration configuration options callback
+   * @param globalHubMode the globalHubMode
+   */
+  public static void init(
+      @NotNull OptionsConfiguration<SentryOptions> optionsConfiguration, boolean globalHubMode) {
+    SentryOptions options = new SentryOptions();
+    optionsConfiguration.configure(options);
+    init(options, globalHubMode);
+  }
+
+  /**
+   * Initializes the SDK with a SentryOptions and globalHubMode
+   *
+   * @param options options the SentryOptions
+   * @param globalHubMode the globalHubMode
+   * @param <T> a class that extends SentryOptions or SentryOptions itself.
+   */
+  private static synchronized <T extends SentryOptions> void init(
+      @NotNull T options, boolean globalHubMode) {
     String dsn = options.getDsn();
     if (dsn == null) {
       throw new IllegalArgumentException("DSN is required. Use empty string to disable SDK.");
@@ -95,6 +135,9 @@ public final class Sentry {
 
     ILogger logger = options.getLogger();
     logger.log(SentryLevel.INFO, "Initializing SDK with DSN: '%s'", options.getDsn());
+
+    logger.log(SentryLevel.INFO, "GlobalHubMode: '%s'", String.valueOf(globalHubMode));
+    Sentry.globalHubMode = globalHubMode;
 
     IHub hub = getCurrentHub();
     mainHub = new Hub(options);
@@ -305,7 +348,7 @@ public final class Sentry {
   /** Pushes a new scope while inheriting the current scope's data. */
   public static void pushScope() {
     // pushScope is no-op in global hub mode
-    if (!isGlobalHubMode) {
+    if (!globalHubMode) {
       getCurrentHub().pushScope();
     }
   }
@@ -313,7 +356,7 @@ public final class Sentry {
   /** Removes the first scope */
   public static void popScope() {
     // popScope is no-op in global hub mode
-    if (!isGlobalHubMode) {
+    if (!globalHubMode) {
       getCurrentHub().popScope();
     }
   }


### PR DESCRIPTION
A Hub per Thread makes sense in server applications.
That's not the case for Mobile or desktop apps. Where it's a single 'user session' for the whole process, UI thread is scarce resource and lots of work are queued to worker threads.

This PR introduces a flag to control the behavior of the `Sentry` static class. By default, it'll continue to clone the `mainHub` per thread. If the flag is flipped (which happens in the Android SDK), a single Hub (and its scope) is shared. Meaning the breadcrumbs added in the UI thread as well as worker threads making HTTP requests also end up on outgoing events.