### PR TITLE
Added HubAdapter to call Sentry static methods from Integrations

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.sentry.core.Hub
+import io.sentry.core.HubAdapter
 import io.sentry.core.SentryOptions
 import java.io.File
 import java.nio.file.Files
@@ -45,8 +46,9 @@ class EnvelopeFileObserverIntegrationTest {
         options.cacheDirPath = file.absolutePath
         options.addIntegration(integrationMock)
         options.setSerializer(mock())
+        val expected = HubAdapter.getInstance()
         val hub = Hub(options)
-        verify(integrationMock).register(hub, options)
+        verify(integrationMock).register(expected, options)
         hub.close()
         verify(integrationMock).close()
     }

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -32,7 +32,7 @@ public final class Hub implements IHub {
 
     // Register integrations against a root Hub
     for (Integration integration : options.getIntegrations()) {
-      integration.register(this, options);
+      integration.register(HubAdapter.getInstance(), options);
     }
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/HubAdapter.java
@@ -1,0 +1,132 @@
+package io.sentry.core;
+
+import io.sentry.core.protocol.SentryId;
+import io.sentry.core.protocol.User;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+
+public final class HubAdapter implements IHub {
+
+  private static final HubAdapter INSTANCE = new HubAdapter();
+
+  private HubAdapter() {}
+
+  public static HubAdapter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return Sentry.isEnabled();
+  }
+
+  @Override
+  public SentryId captureEvent(SentryEvent event, @Nullable Object hint) {
+    return Sentry.captureEvent(event, hint);
+  }
+
+  @Override
+  public SentryId captureMessage(String message, SentryLevel level) {
+    return Sentry.captureMessage(message, level);
+  }
+
+  @Override
+  public SentryId captureException(Throwable throwable, @Nullable Object hint) {
+    return Sentry.captureException(throwable, hint);
+  }
+
+  @Override
+  public void close() {
+    Sentry.close();
+  }
+
+  @Override
+  public void addBreadcrumb(Breadcrumb breadcrumb, @Nullable Object hint) {
+    Sentry.addBreadcrumb(breadcrumb, hint);
+  }
+
+  @Override
+  public void setLevel(SentryLevel level) {
+    Sentry.setLevel(level);
+  }
+
+  @Override
+  public void setTransaction(String transaction) {
+    Sentry.setTransaction(transaction);
+  }
+
+  @Override
+  public void setUser(User user) {
+    Sentry.setUser(user);
+  }
+
+  @Override
+  public void setFingerprint(List<String> fingerprint) {
+    Sentry.setFingerprint(fingerprint);
+  }
+
+  @Override
+  public void clearBreadcrumbs() {
+    Sentry.clearBreadcrumbs();
+  }
+
+  @Override
+  public void setTag(String key, String value) {
+    Sentry.setTag(key, value);
+  }
+
+  @Override
+  public void removeTag(String key) {
+    Sentry.removeTag(key);
+  }
+
+  @Override
+  public void setExtra(String key, String value) {
+    Sentry.setExtra(key, value);
+  }
+
+  @Override
+  public void removeExtra(String key) {
+    Sentry.removeExtra(key);
+  }
+
+  @Override
+  public SentryId getLastEventId() {
+    return Sentry.getLastEventId();
+  }
+
+  @Override
+  public void pushScope() {
+    Sentry.pushScope();
+  }
+
+  @Override
+  public void popScope() {
+    Sentry.popScope();
+  }
+
+  @Override
+  public void withScope(ScopeCallback callback) {
+    Sentry.withScope(callback);
+  }
+
+  @Override
+  public void configureScope(ScopeCallback callback) {
+    Sentry.configureScope(callback);
+  }
+
+  @Override
+  public void bindClient(ISentryClient client) {
+    Sentry.bindClient(client);
+  }
+
+  @Override
+  public void flush(long timeoutMills) {
+    Sentry.flush(timeoutMills);
+  }
+
+  @Override
+  public IHub clone() {
+    return Sentry.getCurrentHub().clone();
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -21,7 +21,7 @@ public final class Sentry {
    *
    * @return the hub
    */
-  private static @NotNull IHub getCurrentHub() {
+  static @NotNull IHub getCurrentHub() {
     IHub hub = currentHub.get();
     if (hub == null) {
       currentHub.set(mainHub.clone());
@@ -280,7 +280,7 @@ public final class Sentry {
    *
    * @param key the key
    */
-  public void removeExtra(@NotNull String key) {
+  public static void removeExtra(@NotNull String key) {
     getCurrentHub().removeExtra(key);
   }
 
@@ -335,7 +335,7 @@ public final class Sentry {
    *
    * @param timeoutMills time in milliseconds
    */
-  public static void flush(int timeoutMills) {
+  public static void flush(long timeoutMills) {
     getCurrentHub().flush(timeoutMills);
   }
 

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -92,8 +92,9 @@ class UncaughtExceptionHandlerIntegrationTest {
         options.addIntegration(integrationMock)
         options.cacheDirPath = file.absolutePath
         options.setSerializer(mock())
+        val expected = HubAdapter.getInstance()
         val hub = Hub(options)
-        verify(integrationMock).register(hub, options)
+        verify(integrationMock).register(expected, options)
         hub.close()
         verify(integrationMock).close()
     }


### PR DESCRIPTION
https://github.com/getsentry/sentry-android/pull/245 was deferred, but we need this change.