### PR TITLE
moving back ANR timeout from long to int param.

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -52,7 +52,7 @@ final class ManifestMetadataReader {
         options.setAnrReportInDebug(isAnrReportInDebug);
 
         long anrTimeoutIntervalMills =
-            metadata.getLong(ANR_TIMEOUT_INTERVAL_MILLS, options.getAnrTimeoutIntervalMills());
+            metadata.getInt(ANR_TIMEOUT_INTERVAL_MILLS, (int) options.getAnrTimeoutIntervalMills());
         options
             .getLogger()
             .log(SentryLevel.DEBUG, "anrTimeoutIntervalMills read: %d", anrTimeoutIntervalMills);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
moving back ANR timeout from long to int param..


## :bulb: Motivation and Context
as a long, it was gonna require that users set value with an "l" or "L" at the end, like 1000l, and might cause a lot of noise to us on support, so a normal int would be fine and we convert it to long.
how it is:
`<meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="1000l" />`

how it's gonna be:
`<meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="1000" />`


## :green_heart: How did you test it?
ran unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
