### PR TITLE
make integrations public

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -12,12 +12,16 @@ import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
-final class AnrIntegration implements Integration, Closeable {
+/**
+ * When the UI thread of an Android app is blocked for too long, an "Application Not Responding"
+ * (ANR) error is triggered. Sends an event if an ANR happens
+ */
+public final class AnrIntegration implements Integration, Closeable {
 
   private static ANRWatchDog anrWatchDog;
 
   @Override
-  public void register(IHub hub, SentryOptions options) {
+  public final void register(IHub hub, SentryOptions options) {
     register(hub, (SentryAndroidOptions) options);
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -10,7 +10,8 @@ import java.io.Closeable;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
-abstract class EnvelopeFileObserverIntegration implements Integration, Closeable {
+/** Watches the envelope dir. and send them (events) over. */
+public abstract class EnvelopeFileObserverIntegration implements Integration, Closeable {
   private @Nullable EnvelopeFileObserver observer;
 
   EnvelopeFileObserverIntegration() {}
@@ -20,7 +21,7 @@ abstract class EnvelopeFileObserverIntegration implements Integration, Closeable
   }
 
   @Override
-  public void register(IHub hub, SentryOptions options) {
+  public final void register(IHub hub, SentryOptions options) {
     ILogger logger = options.getLogger();
     String path = getPath(options);
     if (path == null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -7,13 +7,14 @@ import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
 import java.lang.reflect.Method;
 
-final class NdkIntegration implements Integration {
+/** Enables the NDK error reporting for Android */
+public final class NdkIntegration implements Integration {
   private boolean isNdkAvailable() {
     return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
   }
 
   @Override
-  public void register(IHub hub, SentryOptions options) {
+  public final void register(IHub hub, SentryOptions options) {
     // Note: `hub` isn't used here because the NDK integration writes files to disk which are picked
     // up by another
     // integration. The NDK directory watching must happen before this integration runs.

--- a/sentry-core/src/main/java/io/sentry/core/Integration.java
+++ b/sentry-core/src/main/java/io/sentry/core/Integration.java
@@ -1,5 +1,15 @@
 package io.sentry.core;
 
+/**
+ * Code that provides middlewares, bindings or hooks into certain frameworks or environments, along
+ * with code that inserts those bindings and activates them.
+ */
 public interface Integration {
+  /**
+   * Registers an integration
+   *
+   * @param hub the Hub
+   * @param options the options
+   */
   void register(IHub hub, SentryOptions options);
 }

--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
@@ -4,7 +4,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.jetbrains.annotations.NotNull;
 
-final class SendCachedEventFireAndForgetIntegration implements Integration {
+/** Sends cached events over when your App. is starting. */
+public final class SendCachedEventFireAndForgetIntegration implements Integration {
 
   private final SendFireAndForgetFactory factory;
 
@@ -22,7 +23,7 @@ final class SendCachedEventFireAndForgetIntegration implements Integration {
 
   @SuppressWarnings("FutureReturnValueIgnored")
   @Override
-  public void register(@NotNull IHub hub, @NotNull SentryOptions options) {
+  public final void register(@NotNull IHub hub, @NotNull SentryOptions options) {
     String cachedDir = options.getCacheDirPath();
     if (cachedDir == null) {
       options.getLogger().log(SentryLevel.WARNING, "No cache dir path is defined in options.");

--- a/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/UncaughtExceptionHandlerIntegration.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.TestOnly;
  * Sends any uncaught exception to Sentry, then passes the exception on to the pre-existing uncaught
  * exception handler.
  */
-final class UncaughtExceptionHandlerIntegration
+public final class UncaughtExceptionHandlerIntegration
     implements Integration, Thread.UncaughtExceptionHandler, Closeable {
   /** Reference to the pre-existing uncaught exception handler. */
   private Thread.UncaughtExceptionHandler defaultExceptionHandler;
@@ -36,7 +36,7 @@ final class UncaughtExceptionHandlerIntegration
   }
 
   @Override
-  public void register(IHub hub, SentryOptions options) {
+  public final void register(IHub hub, SentryOptions options) {
     if (registered) {
       options
           .getLogger()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
make integrations public.


## :bulb: Motivation and Context
When a user wants to remove an integration, it would be possible doing:
options.getIntegrations() iterating it and comparing instances, but integrations are not public, yet.

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
