### PR TITLE
fixes #259 - NPE check on getExternalFilesDirs items.

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -658,6 +658,11 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       String internalStoragePath =
           internalStorage != null ? internalStorage.getAbsolutePath() : null;
       for (File file : externalFilesDirs) {
+        // externalFilesDirs may contain null values :(
+        if (file == null) {
+          continue;
+        }
+
         // return the 1st file if you cannot compare with the internal one
         if (internalStoragePath == null || internalStoragePath.isEmpty()) {
           return file;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fixes #259 - NPE check on getExternalFilesDirs items.


## :bulb: Motivation and Context
https://developer.android.com/reference/android/content/Context.html#getExternalFilesDirs(java.lang.String)

> the absolute paths to application-specific directories. Some individual paths may be null if that shared storage is not currently available. The first path returned is the same as getExternalFilesDir(java.lang.String).


## :green_heart: How did you test it?
Ran on Nexus 5X API 21 emulator.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
