### PR TITLE
Support mills timestamp format

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/adapters/DateDeserializerAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/adapters/DateDeserializerAdapter.java
@@ -27,7 +27,15 @@ public final class DateDeserializerAdapter implements JsonDeserializer<Date> {
     try {
       return json == null ? null : DateUtils.getDateTime(json.getAsString());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing Date", e);
+      logger.log(
+          SentryLevel.ERROR,
+          "Error when deserializing UTC timestamp format, might be mills timestamp format.",
+          e);
+    }
+    try {
+      return DateUtils.getDateTimeWithMillsPrecision(json.getAsString());
+    } catch (Exception e) {
+      logger.log(SentryLevel.ERROR, "Error when deserializing mills timestamp format.", e);
     }
     return null;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/adapters/DateDeserializerAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/adapters/DateDeserializerAdapter.java
@@ -28,8 +28,8 @@ public final class DateDeserializerAdapter implements JsonDeserializer<Date> {
       return json == null ? null : DateUtils.getDateTime(json.getAsString());
     } catch (Exception e) {
       logger.log(
-          SentryLevel.ERROR,
-          "Error when deserializing UTC timestamp format, might be mills timestamp format.",
+          SentryLevel.DEBUG,
+          "Error when deserializing UTC timestamp format, it might be mills timestamp format.",
           e);
     }
     try {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidSerializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidSerializerTest.kt
@@ -74,6 +74,30 @@ class AndroidSerializerTest {
     }
 
     @Test
+    fun `when deserializing mills timestamp, it should become a SentryEvent-Date`() {
+        val dateIsoFormat = "1581410911"
+        val expected = DateUtils.getDateTimeWithMillsPrecision(dateIsoFormat)
+
+        val jsonEvent = "{\"timestamp\":\"$dateIsoFormat\"}"
+
+        val actual = serializer.deserializeEvent(StringReader(jsonEvent))
+
+        assertEquals(expected, actual.timestamp)
+    }
+
+    @Test
+    fun `when deserializing mills timestamp with mills precision, it should become a SentryEvent-Date`() {
+        val dateIsoFormat = "1581410911.988"
+        val expected = DateUtils.getDateTimeWithMillsPrecision(dateIsoFormat)
+
+        val jsonEvent = "{\"timestamp\":\"$dateIsoFormat\"}"
+
+        val actual = serializer.deserializeEvent(StringReader(jsonEvent))
+
+        assertEquals(expected, actual.timestamp)
+    }
+
+    @Test
     fun `when deserializing unknown properties, it should be added to unknown field`() {
         val sentryEvent = generateEmptySentryEvent()
         sentryEvent.eventId = null

--- a/sentry-core/src/main/java/io/sentry/core/DateUtils.java
+++ b/sentry-core/src/main/java/io/sentry/core/DateUtils.java
@@ -40,9 +40,9 @@ public final class DateUtils {
   }
 
   /**
-   * Get date
+   * Get Java Date from UTC timestamp format
    *
-   * @param timestamp already UTC format
+   * @param timestamp UTC format eg 2000-12-31T23:59:58Z
    * @return the Date
    */
   public static Date getDateTime(String timestamp) throws IllegalArgumentException {
@@ -51,6 +51,25 @@ public final class DateUtils {
       return df.parse(timestamp);
     } catch (ParseException e) {
       throw new IllegalArgumentException("timestamp is not ISO format " + timestamp);
+    }
+  }
+
+  /**
+   * Get Java Date from mills timestamp format
+   *
+   * @param timestamp mills format eg 1581410911.988 (1581410911 seconds and 988 mills)
+   * @return the Date
+   */
+  public static Date getDateTimeWithMillsPrecision(String timestamp)
+      throws IllegalArgumentException {
+    try {
+      String[] times = timestamp.split("\\.", -1);
+      long seconds = Long.parseLong(times[0]);
+      long mills = times.length > 1 ? Long.parseLong(times[1]) : 0;
+
+      return new Date((seconds * 1000) + mills);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("timestamp is not mills format " + timestamp);
     }
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Support mills timestamp format.
eg 1581410911.988
which is {seconds}.{mills}

## :bulb: Motivation and Context
JS sends mills timestamp format and we need to support hybrid SDKs.


## :green_heart: How did you test it?
unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
