### PR TITLE
feat: attach threads/stacktraces

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -19,7 +19,8 @@ public final class MainEventProcessor implements EventProcessor {
         new SentryStackTraceFactory(options.getInAppExcludes(), options.getInAppIncludes());
 
     sentryExceptionFactory = new SentryExceptionFactory(sentryStackTraceFactory);
-    sentryThreadFactory = new SentryThreadFactory(sentryStackTraceFactory);
+    sentryThreadFactory =
+        new SentryThreadFactory(sentryStackTraceFactory, this.options.isAttachStacktrace());
   }
 
   MainEventProcessor(
@@ -71,15 +72,8 @@ public final class MainEventProcessor implements EventProcessor {
       event.setDist(options.getDist());
     }
 
-    if (event.getThreads() == null) {
-      // that means user has called Sentry.captureMessage
-      if (event.getMessage() != null && event.getExceptions() == null) {
-        if (options.isAttachStacktrace()) {
-          event.setThreads(sentryThreadFactory.getCurrentThreads());
-        }
-      } else {
-        event.setThreads(sentryThreadFactory.getCurrentThreads());
-      }
+    if (event.getThreads() == null && options.isAttachThreads()) {
+      event.setThreads(sentryThreadFactory.getCurrentThreads());
     }
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -72,7 +72,14 @@ public final class MainEventProcessor implements EventProcessor {
     }
 
     if (event.getThreads() == null) {
-      event.setThreads(sentryThreadFactory.getCurrentThreads());
+      // that means user has called Sentry.captureMessage
+      if (event.getMessage() != null && event.getExceptions() == null) {
+        if (options.isAttachStacktrace()) {
+          event.setThreads(sentryThreadFactory.getCurrentThreads());
+        }
+      } else {
+        event.setThreads(sentryThreadFactory.getCurrentThreads());
+      }
     }
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -137,9 +137,12 @@ public class SentryOptions {
   /** Sets the distribution. Think about it together with release and environment */
   private @Nullable String dist;
 
+  /** When enabled, threads are automatically attached to all logged events. */
+  private boolean attachThreads = true;
+
   /**
-   * When enabled, stack traces are automatically attached to all messages logged. Stack traces are
-   * always attached to exceptions but when this is set stack traces are also sent with messages
+   * When enabled, stack traces are automatically attached to all threads logged. Stack traces are
+   * always attached to exceptions but when this is set stack traces are also sent with threads
    */
   private boolean attachStacktrace;
 
@@ -609,6 +612,24 @@ public class SentryOptions {
    */
   public void setAttachStacktrace(boolean attachStacktrace) {
     this.attachStacktrace = attachStacktrace;
+  }
+
+  /**
+   * Checks if the AttachThreads is enabled or not
+   *
+   * @return true if enabled or false otherwise
+   */
+  public boolean isAttachThreads() {
+    return attachThreads;
+  }
+
+  /**
+   * Sets the attachThreads to enabled or disabled
+   *
+   * @param attachThreads true if enabled or false otherwise
+   */
+  public void setAttachThreads(boolean attachThreads) {
+    this.attachThreads = attachThreads;
   }
 
   /** The BeforeSend callback */

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -138,6 +138,12 @@ public class SentryOptions {
   private @Nullable String dist;
 
   /**
+   * When enabled, stack traces are automatically attached to all messages logged. Stack traces are
+   * always attached to exceptions but when this is set stack traces are also sent with messages
+   */
+  private boolean attachStacktrace;
+
+  /**
    * Adds an event processor
    *
    * @param eventProcessor the event processor
@@ -585,6 +591,24 @@ public class SentryOptions {
    */
   public void setTransportGate(@Nullable ITransportGate transportGate) {
     this.transportGate = transportGate;
+  }
+
+  /**
+   * Checks if the AttachStacktrace is enabled or not
+   *
+   * @return true if enabled or false otherwise
+   */
+  public boolean isAttachStacktrace() {
+    return attachStacktrace;
+  }
+
+  /**
+   * Sets the attachStacktrace to enabled or disabled
+   *
+   * @param attachStacktrace true if enabled or false otherwise
+   */
+  public void setAttachStacktrace(boolean attachStacktrace) {
+    this.attachStacktrace = attachStacktrace;
   }
 
   /** The BeforeSend callback */

--- a/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
@@ -18,13 +18,31 @@ final class SentryThreadFactory {
   private final @NotNull SentryStackTraceFactory sentryStackTraceFactory;
 
   /**
+   * When enabled, stack traces are automatically attached to all threads logged. Stack traces are
+   * always attached to exceptions but when this is set stack traces are also sent with threads
+   */
+  private final boolean attachStacktrace;
+
+  /**
+   * ctor SentryThreadFactory that takes a SentryStackTraceFactory
+   *
+   * @param sentryStackTraceFactory the SentryStackTraceFactory
+   * @param attachStacktrace the attachStacktrace
+   */
+  public SentryThreadFactory(
+      final @NotNull SentryStackTraceFactory sentryStackTraceFactory, boolean attachStacktrace) {
+    this.sentryStackTraceFactory =
+        Objects.requireNonNull(sentryStackTraceFactory, "The SentryStackTraceFactory is required.");
+    this.attachStacktrace = attachStacktrace;
+  }
+
+  /**
    * ctor SentryThreadFactory that takes a SentryStackTraceFactory
    *
    * @param sentryStackTraceFactory the SentryStackTraceFactory
    */
   public SentryThreadFactory(final @NotNull SentryStackTraceFactory sentryStackTraceFactory) {
-    this.sentryStackTraceFactory =
-        Objects.requireNonNull(sentryStackTraceFactory, "The SentryStackTraceFactory is required.");
+    this(sentryStackTraceFactory, false);
   }
 
   /**
@@ -92,7 +110,7 @@ final class SentryThreadFactory {
     final List<SentryStackFrame> frames =
         sentryStackTraceFactory.getStackFrames(stackFramesElements);
 
-    if (frames != null && frames.size() > 0) {
+    if (attachStacktrace && frames != null && frames.size() > 0) {
       sentryThread.setStacktrace(new SentryStackTrace(frames));
     }
 

--- a/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 
 class MainEventProcessorTest {
     class Fixture(attachStacktrace: Boolean = false) {
-        val sentryOptions: SentryOptions = SentryOptions().apply {
+        private val sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString
             release = "release"
             environment = "environment"

--- a/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
@@ -2,6 +2,7 @@ package io.sentry.core
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
@@ -9,28 +10,46 @@ import kotlin.test.assertTrue
 
 class SentryThreadFactoryTest {
 
-    private val sut = SentryThreadFactory(SentryStackTraceFactory(listOf("io.sentry"), listOf()))
+    class Fixture {
+        internal fun getSut(attachStacktrace: Boolean = true) = SentryThreadFactory(SentryStackTraceFactory(listOf("io.sentry"), listOf()), attachStacktrace)
+    }
+
+    private val fixture = Fixture()
 
     @Test
     fun `when getCurrentThreads is called, not empty result`() {
+        val sut = fixture.getSut()
         val threads = sut.currentThreads
         assertNotSame(0, threads!!.count())
     }
 
     @Test
-    fun `when currentThreads is called, current thread is marked crashed`() =
+    fun `when currentThreads is called, current thread is marked crashed`() {
+        val sut = fixture.getSut()
         assertEquals(1, sut.currentThreads!!.filter { it.isCrashed }.count())
+    }
 
     @Test
-    fun `when currentThreads is called, thread state is captured`() =
+    fun `when currentThreads is called, thread state is captured`() {
+        val sut = fixture.getSut()
         assertTrue(sut.currentThreads!!.all { it.state != null })
+    }
 
     @Test
-    fun `when currentThreads is called, some thread stack frames are captured`() =
+    fun `when currentThreads is called, some thread stack frames are captured`() {
+        val sut = fixture.getSut()
         assertTrue(sut.currentThreads!!.filter { it.stacktrace != null }.any { it.stacktrace.frames.count() > 0 })
+    }
+
+    @Test
+    fun `when currentThreads and attachStacktrace is disabled, stack frames are not captured`() {
+        val sut = fixture.getSut(false)
+        assertFalse(sut.currentThreads!!.filter { it.stacktrace != null }.any { it.stacktrace.frames.count() > 0 })
+    }
 
     @Test
     fun `when getAllStackTraces don't return the current thread, add it manually`() {
+        val sut = fixture.getSut()
         val stackTraces = Thread.getAllStackTraces()
         val currentThread = Thread.currentThread()
         stackTraces.remove(currentThread)
@@ -42,6 +61,7 @@ class SentryThreadFactoryTest {
 
     @Test
     fun `When passing empty param to getCurrentThreads, returns null`() {
+        val sut = fixture.getSut()
         val threads = sut.getCurrentThreads(mapOf())
 
         assertNull(threads)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
feat: attach stacktraces


## :bulb: Motivation and Context
attach stacktraces is disabled by default, but it should have a flag to opt-in.
right now is enabled by default and there's no opt-out.


## :green_heart: How did you test it?
unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
