### PR TITLE
fix android lint warning

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -497,6 +497,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
    *
    * @return the device's current screen orientation, or null if unknown
    */
+  @SuppressWarnings("deprecation")
   private Device.DeviceOrientation getOrientation() {
     try {
       switch (context.getResources().getConfiguration().orientation) {
@@ -504,10 +505,14 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
           return Device.DeviceOrientation.LANDSCAPE;
         case Configuration.ORIENTATION_PORTRAIT:
           return Device.DeviceOrientation.PORTRAIT;
+        case Configuration.ORIENTATION_SQUARE:
+        case Configuration.ORIENTATION_UNDEFINED:
         default:
           options
               .getLogger()
-              .log(SentryLevel.INFO, "No device orientation available (ORIENTATION_UNDEFINED)");
+              .log(
+                  SentryLevel.INFO,
+                  "No device orientation available (ORIENTATION_SQUARE|ORIENTATION_UNDEFINED)");
           return null;
       }
     } catch (Exception e) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix android lint warning.


## :bulb: Motivation and Context
if using `buildToolsVersion = "30.0.0-rc1"` project won't compile due new linting.


## :green_heart: How did you test it?
building it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
