### PR TITLE
set current threadId when theres no mechanism to rely on

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryExceptionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryExceptionFactory.java
@@ -126,7 +126,7 @@ final class SentryExceptionFactory {
         thread = exceptionMechanismThrowable.getThread();
       } else {
         exceptionMechanism = null;
-        thread = null;
+        thread = Thread.currentThread();
       }
 
       SentryException exception = getSentryException(currentThrowable, exceptionMechanism, thread);

--- a/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
@@ -67,7 +67,6 @@ class SentryExceptionFactoryTest {
 
     @Test
     fun `when exception has a mechanism, it should get and set the mechanism's threadId`() {
-        val threadId = Thread.currentThread().id
         val exception = Exception("message")
         val mechanism = Mechanism()
         mechanism.type = "ANR"

--- a/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
@@ -56,5 +56,28 @@ class SentryExceptionFactoryTest {
         assertEquals("SentryExceptionFactoryTest\$InnerClassThrowable", queue.first.type)
     }
 
+    @Test
+    fun `when exception has no mechanism, it should get and set the current threadId`() {
+        val threadId = Thread.currentThread().id
+        val exception = Exception("message", Exception("cause"))
+        val queue = sut.extractExceptionQueue(exception)
+
+        assertEquals(threadId, queue.first.threadId)
+    }
+
+    @Test
+    fun `when exception has a mechanism, it should get and set the mechanism's threadId`() {
+        val threadId = Thread.currentThread().id
+        val exception = Exception("message")
+        val mechanism = Mechanism()
+        mechanism.type = "ANR"
+        val thread = Thread()
+        val throwable = ExceptionMechanismException(mechanism, exception, thread)
+
+        val queue = sut.extractExceptionQueue(throwable)
+
+        assertEquals(thread.id, queue.first.threadId)
+    }
+
     private inner class InnerClassThrowable constructor(cause: Throwable? = null) : Throwable(cause)
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
set current threadId when theres no mechanism to rely on.


## :bulb: Motivation and Context
exception had no threadId if it was not a exception mechanism and this makes the thread selector not happy on the dashboard.


## :green_heart: How did you test it?
unit test and debugging it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
