### PR TITLE
Add the default serverName to SentryOptions and use it in MainEventProcessor

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -67,7 +67,9 @@ public final class MainEventProcessor implements EventProcessor {
     if (event.getEnvironment() == null) {
       event.setEnvironment(options.getEnvironment());
     }
-
+    if (event.getServerName() == null) {
+      event.setServerName(options.getServerName());
+    }
     if (event.getDist() == null) {
       event.setDist(options.getDist());
     }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -146,6 +146,9 @@ public class SentryOptions {
    */
   private boolean attachStacktrace;
 
+  /** The server name used in the Sentry messages. */
+  private String serverName;
+
   /**
    * Adds an event processor
    *
@@ -630,6 +633,24 @@ public class SentryOptions {
    */
   public void setAttachThreads(boolean attachThreads) {
     this.attachThreads = attachThreads;
+  }
+
+  /**
+   * Gets the default server name to be used in Sentry events.
+   *
+   * @return the default server name or null if none set
+   */
+  public @Nullable String getServerName() {
+    return serverName;
+  }
+
+  /**
+   * Sets the default server name to be used in Sentry events.
+   *
+   * @param serverName the default server name or null if none should be used
+   */
+  public void setServerName(@Nullable String serverName) {
+    this.serverName = serverName;
   }
 
   /** The BeforeSend callback */

--- a/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
@@ -16,6 +16,7 @@ class MainEventProcessorTest {
             release = "release"
             environment = "environment"
             dist = "dist"
+            serverName = "server"
         }
         fun getSut(attachThreads: Boolean = true): MainEventProcessor {
             sentryOptions.isAttachThreads = attachThreads
@@ -48,6 +49,7 @@ class MainEventProcessorTest {
         assertEquals("release", event.release)
         assertEquals("environment", event.environment)
         assertEquals("dist", event.dist)
+        assertEquals("server", event.serverName)
         assertTrue(event.threads.first { t -> t.id == crashedThread.id }.isCrashed)
     }
 
@@ -58,12 +60,14 @@ class MainEventProcessorTest {
         event.dist = "eventDist"
         event.environment = "eventEnvironment"
         event.release = "eventRelease"
+        event.serverName = "eventServerName"
 
         event = sut.process(event, null)
 
         assertEquals("eventRelease", event.release)
         assertEquals("eventEnvironment", event.environment)
         assertEquals("eventDist", event.dist)
+        assertEquals("eventServerName", event.serverName)
     }
 
     @Test
@@ -75,6 +79,8 @@ class MainEventProcessorTest {
 
         assertNull(event.release)
         assertNull(event.environment)
+        assertNull(event.dist)
+        assertNull(event.serverName)
         assertNull(event.threads)
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
This adds support for the default server name specified in sentry options so that it can be used in events.


## :bulb: Motivation and Context
This feature exists in `sentry-java` and is a documented Sentry option, e.g. https://docs.sentry.io/error-reporting/configuration/?platform=csharp#server-name

## :green_heart: How did you test it?
Updated the unit tests of the `MainEventProcessor` to test that the option is applied.

## :pencil: Checklist
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing

