### PR TITLE
Enable the initialization using argument passing style in addition to the callback style configuration.

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -118,10 +118,9 @@ public final class Sentry {
    *
    * @param options options the SentryOptions
    * @param globalHubMode the globalHubMode
-   * @param <T> a class that extends SentryOptions or SentryOptions itself.
    */
-  private static synchronized <T extends SentryOptions> void init(
-      @NotNull T options, boolean globalHubMode) {
+  public static synchronized void init(
+      @NotNull SentryOptions options, boolean globalHubMode) {
     String dsn = options.getDsn();
     if (dsn == null) {
       throw new IllegalArgumentException("DSN is required. Use empty string to disable SDK.");


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Currently, Sentry only allows for callback-style initialization using `OptionsConfiguration` interface passed into the `Sentry.init()` methods. This PR makes available to users also the initialization method that merely accepts the `SentryOptions` instance.

Additionally, I've removed the unnecessary generic parameter on the `init` method that was made public, because it naturally accepts any subclass of `SentryOptions` just by inheritance rules.

## :bulb: Motivation and Context
The callback-based initialization is limiting in the injection-based environments like Spring or CDI where instances are produced and injected rather than modified through a callback.

## :green_heart: How did you test it?
N/A

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing