### PR TITLE
apply scope's data if event is cached but handled

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -3,6 +3,7 @@ package io.sentry.core;
 import io.sentry.core.cache.DiskCache;
 import io.sentry.core.cache.IEventCache;
 import io.sentry.core.hints.Cached;
+import io.sentry.core.hints.Handled;
 import io.sentry.core.protocol.SentryId;
 import io.sentry.core.transport.Connection;
 import io.sentry.core.transport.ITransport;
@@ -72,7 +73,8 @@ public final class SentryClient implements ISentryClient {
 
     options.getLogger().log(SentryLevel.DEBUG, "Capturing event: %s", event.getEventId());
 
-    if (!(hint instanceof Cached)) {
+    // if event is cached, but handled, its fine to apply scope's data
+    if (!(hint instanceof Cached) || ((hint instanceof Handled) && ((Handled) hint).isHandled())) {
       // Event has already passed through here before it was cached
       // Going through again could be reading data that is no longer relevant
       // i.e proguard id, app version, threads

--- a/sentry-core/src/main/java/io/sentry/core/hints/Handled.java
+++ b/sentry-core/src/main/java/io/sentry/core/hints/Handled.java
@@ -1,0 +1,12 @@
+package io.sentry.core.hints;
+
+// Marker interface for a capture involving data cached from disk
+// This means applying data relevant to the current execution should be done
+// as the App. has handled the error and App won't crash.
+// like applying threads or current app version.
+public interface Handled {
+  // this could also be in Cached hint as well, just making a new to to exemplify easily
+  void setHandled(boolean handled);
+
+  boolean isHandled();
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
apply scope's data if event is cached but handled


## :bulb: Motivation and Context
right now events that are cached never apply the scope's data.
an event can be cached but handled, we'd like to apply scope's data.
an event can be cached, handled, but we shouldn't apply scope's data as the App. has been killed later on.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
