### PR TITLE
renaming session cache interface

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/AsyncConnectionFactory.java
@@ -1,14 +1,14 @@
 package io.sentry.core;
 
+import io.sentry.core.cache.IEnvelopeCache;
 import io.sentry.core.cache.IEventCache;
-import io.sentry.core.cache.ISessionCache;
 import io.sentry.core.transport.AsyncConnection;
 
 final class AsyncConnectionFactory {
   private AsyncConnectionFactory() {}
 
   public static AsyncConnection create(
-      SentryOptions options, IEventCache eventCache, ISessionCache sessionCache) {
+      SentryOptions options, IEventCache eventCache, IEnvelopeCache sessionCache) {
 
     // the connection doesn't do any retries of failed sends and can hold at most the same number
     // of pending events as there are being cached. The rest is dropped.

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -1,8 +1,8 @@
 package io.sentry.core;
 
 import io.sentry.core.cache.DiskCache;
+import io.sentry.core.cache.IEnvelopeCache;
 import io.sentry.core.cache.IEventCache;
-import io.sentry.core.cache.ISessionCache;
 import io.sentry.core.cache.SessionCache;
 import io.sentry.core.hints.Cached;
 import io.sentry.core.hints.SessionUpdateHint;
@@ -57,7 +57,7 @@ public final class SentryClient implements ISentryClient {
     if (connection == null) {
       // TODO this is obviously provisional and should be constructed based on the config in options
       final IEventCache cache = new DiskCache(options);
-      final ISessionCache sessionCache = new SessionCache(options);
+      final IEnvelopeCache sessionCache = new SessionCache(options);
 
       connection = AsyncConnectionFactory.create(options, cache, sessionCache);
     }

--- a/sentry-core/src/main/java/io/sentry/core/cache/IEnvelopeCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/IEnvelopeCache.java
@@ -3,7 +3,7 @@ package io.sentry.core.cache;
 import io.sentry.core.SentryEnvelope;
 import org.jetbrains.annotations.Nullable;
 
-public interface ISessionCache extends Iterable<SentryEnvelope> {
+public interface IEnvelopeCache extends Iterable<SentryEnvelope> {
 
   void store(SentryEnvelope envelope, @Nullable Object hint);
 

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
-public final class SessionCache implements ISessionCache {
+public final class SessionCache implements IEnvelopeCache {
 
   /** File suffix added to all serialized envelopes files. */
   static final String SUFFIX_ENVELOPE_FILE = ".envelope";

--- a/sentry-core/src/main/java/io/sentry/core/transport/NoOpEnvelopeCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/NoOpEnvelopeCache.java
@@ -1,16 +1,16 @@
 package io.sentry.core.transport;
 
 import io.sentry.core.SentryEnvelope;
-import io.sentry.core.cache.ISessionCache;
+import io.sentry.core.cache.IEnvelopeCache;
 import java.util.ArrayList;
 import java.util.Iterator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-final class NoOpSessionCache implements ISessionCache {
-  private static final NoOpSessionCache instance = new NoOpSessionCache();
+final class NoOpEnvelopeCache implements IEnvelopeCache {
+  private static final NoOpEnvelopeCache instance = new NoOpEnvelopeCache();
 
-  public static NoOpSessionCache getInstance() {
+  public static NoOpEnvelopeCache getInstance() {
     return instance;
   }
 

--- a/sentry-core/src/test/java/io/sentry/core/cache/SessionCacheTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/cache/SessionCacheTest.kt
@@ -34,7 +34,7 @@ class SessionCacheTest {
         val options = SentryOptions()
         val logger = mock<ILogger>()
 
-        fun getSUT(): ISessionCache {
+        fun getSUT(): IEnvelopeCache {
             options.sessionsDirSize = maxSize
             options.cacheDirPath = dir.toAbsolutePath().toFile().absolutePath
             File(options.sessionsPath!!).mkdirs()

--- a/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
@@ -15,8 +15,8 @@ import io.sentry.core.SentryEnvelopeItem
 import io.sentry.core.SentryEvent
 import io.sentry.core.SentryOptions
 import io.sentry.core.Session
+import io.sentry.core.cache.IEnvelopeCache
 import io.sentry.core.cache.IEventCache
-import io.sentry.core.cache.ISessionCache
 import io.sentry.core.dsnString
 import java.io.IOException
 import java.util.concurrent.ExecutorService
@@ -29,7 +29,7 @@ class AsyncConnectionTest {
         var transport = mock<ITransport>()
         var transportGate = mock<ITransportGate>()
         var eventCache = mock<IEventCache>()
-        var sessionCache = mock<ISessionCache>()
+        var sessionCache = mock<IEnvelopeCache>()
         var executor = mock<ExecutorService>()
         var sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
renaming session cache interface, implementation is still called SessionCache as it takes a SentryOptions and reads session path, etc...


## :bulb: Motivation and Context
following Open–closed principle


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
