### PR TITLE
session duration should be in seconds, sequence should be UTC

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Session.java
+++ b/sentry-core/src/main/java/io/sentry/core/Session.java
@@ -193,10 +193,21 @@ public final class Session {
         started = timestamp;
       }
 
-      long diff = Math.abs(timestamp.getTime() - started.getTime());
-      duration = (double) diff;
-      sequence = System.currentTimeMillis();
+      duration = calculateDurationTime(timestamp, started);
+      sequence = getSequenceTimestamp();
     }
+  }
+
+  /**
+   * Calculates the duration time in seconds timestamp (last update) - started
+   *
+   * @param timestamp the timestamp
+   * @param started the started timestamp
+   * @return duration in seconds
+   */
+  private Double calculateDurationTime(final @NotNull Date timestamp, final @NotNull Date started) {
+    long diff = Math.abs(timestamp.getTime() - started.getTime());
+    return (double) diff / 1000; // duration in seconds
   }
 
   /**
@@ -227,9 +238,18 @@ public final class Session {
       if (sessionHasBeenUpdated) {
         init = null;
         timestamp = DateUtils.getCurrentDateTime();
-        sequence = System.currentTimeMillis();
+        sequence = getSequenceTimestamp();
       }
       return sessionHasBeenUpdated;
     }
+  }
+
+  /**
+   * Returns a logical clock.
+   *
+   * @return time stamp in milliseconds UTC
+   */
+  private Long getSequenceTimestamp() {
+    return DateUtils.getCurrentDateTime().getTime();
   }
 }

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -28,7 +28,6 @@
     </activity>
 
     <!--  NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
-<!--    <meta-data android:name="io.sentry.dsn" android:value="http://1511aad18ebc4bc1a30fa8291a884314@marandaneto.ngrok.io/1" />-->
     <meta-data android:name="io.sentry.dsn" android:value="https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954" />
 
 
@@ -53,9 +52,16 @@
 <!--    how to disable the NDK-->
 <!--    <meta-data android:name="io.sentry.ndk.enable" android:value="false" />-->
 
-<!--    <meta-data android:name="io.sentry.release" android:value="io.sentry.android@2.0.2+20018" />-->
+<!--    how to set a release-->
+<!--    <meta-data android:name="io.sentry.release" android:value="io.sentry.sample@1.0.0+10001" />-->
+
+<!--    how to enable session tracking-->
     <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />
-    <meta-data android:name="io.sentry.environment" android:value="debug" />
+
+<!--    how to set a environment-->
+<!--    <meta-data android:name="io.sentry.environment" android:value="debug" />-->
+
+<!--    how to change a session tracking interval-->
     <meta-data android:name="io.sentry.session-tracking.timeout-interval-millis" android:value="10000" />
   </application>
 </manifest>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
session duration should be in seconds.
sequence was current timezone


## :bulb: Motivation and Context
duration was in millis.
sequence is UTC.


## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
