### PR TITLE
renaming transport gate method

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransportGate.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransportGate.java
@@ -18,7 +18,7 @@ final class AndroidTransportGate implements ITransportGate {
   }
 
   @Override
-  public boolean isSendingAllowed() {
+  public boolean isConnected() {
     return isConnected(ConnectivityChecker.isConnected(context, logger));
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransportGateTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransportGateTest.kt
@@ -25,7 +25,7 @@ class AndroidTransportGateTest {
 
     @Test
     fun `isSendingAllowed is not null`() {
-        assertNotNull(transportGate.isSendingAllowed)
+        assertNotNull(transportGate.isConnected)
     }
 
     @Test

--- a/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
@@ -234,7 +234,7 @@ public final class AsyncConnection implements Closeable, Connection {
             .log(SentryLevel.DEBUG, "Disk flush event fired: %s", event.getEventId());
       }
 
-      if (transportGate.isSendingAllowed()) {
+      if (transportGate.isConnected()) {
         try {
           result = transport.send(event);
           if (result.isSuccess()) {
@@ -317,7 +317,7 @@ public final class AsyncConnection implements Closeable, Connection {
         return TransportResult.success();
       }
 
-      if (transportGate.isSendingAllowed()) {
+      if (transportGate.isConnected()) {
         try {
           result = transport.send(envelope);
           if (result.isSuccess()) {

--- a/sentry-core/src/main/java/io/sentry/core/transport/ITransportGate.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/ITransportGate.java
@@ -11,5 +11,5 @@ package io.sentry.core.transport;
 public interface ITransportGate {
 
   /** @return true if it is possible to send events to the Sentry server, false otherwise */
-  boolean isSendingAllowed();
+  boolean isConnected();
 }

--- a/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
@@ -396,7 +396,7 @@ class SentryClientTest {
         SentryClient(sentryOptions, connection)
 
         assertNotNull(sentryOptions.transportGate)
-        assertTrue(sentryOptions.transportGate!!.isSendingAllowed)
+        assertTrue(sentryOptions.transportGate!!.isConnected)
     }
 
     @Test
@@ -612,7 +612,7 @@ class SentryClientTest {
     }
 
     internal class CustomTransportGate : ITransportGate {
-        override fun isSendingAllowed(): Boolean = false
+        override fun isConnected(): Boolean = false
     }
 
     internal class CustomCachedApplyScopeDataHint : Cached, ApplyScopeData

--- a/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/AsyncConnectionTest.kt
@@ -55,7 +55,7 @@ class AsyncConnectionTest {
     fun `successful send discards the event from cache`() {
         // given
         val ev = mock<SentryEvent>()
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(true)
+        whenever(fixture.transportGate.isConnected).thenReturn(true)
         whenever(fixture.transport.send(any<SentryEvent>())).thenReturn(TransportResult.success())
 
         // when
@@ -75,7 +75,7 @@ class AsyncConnectionTest {
     fun `successful send discards the session from cache`() {
         // given
         val envelope = SentryEnvelope.fromSession(fixture.sentryOptions.serializer, createSession())
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(true)
+        whenever(fixture.transportGate.isConnected).thenReturn(true)
         whenever(fixture.transport.send(any<SentryEnvelope>())).thenReturn(TransportResult.success())
 
         // when
@@ -95,7 +95,7 @@ class AsyncConnectionTest {
     fun `stores event in cache if sending is not allowed`() {
         // given
         val ev = mock<SentryEvent>()
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(false)
+        whenever(fixture.transportGate.isConnected).thenReturn(false)
 
         // when
         fixture.getSUT().send(ev)
@@ -109,7 +109,7 @@ class AsyncConnectionTest {
     fun `stores session in cache if sending is not allowed`() {
         // given
         val envelope = SentryEnvelope.fromSession(fixture.sentryOptions.serializer, createSession())
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(false)
+        whenever(fixture.transportGate.isConnected).thenReturn(false)
 
         // when
         fixture.getSUT().send(envelope)
@@ -123,7 +123,7 @@ class AsyncConnectionTest {
     fun `stores event after unsuccessful send`() {
         // given
         val ev = mock<SentryEvent>()
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(true)
+        whenever(fixture.transportGate.isConnected).thenReturn(true)
         whenever(fixture.transport.send(any<SentryEvent>())).thenReturn(TransportResult.error(500))
 
         // when
@@ -147,7 +147,7 @@ class AsyncConnectionTest {
     fun `stores session after unsuccessful send`() {
         // given
         val envelope = SentryEnvelope.fromSession(fixture.sentryOptions.serializer, createSession())
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(true)
+        whenever(fixture.transportGate.isConnected).thenReturn(true)
         whenever(fixture.transport.send(any<SentryEnvelope>())).thenReturn(TransportResult.error(500))
 
         // when
@@ -171,7 +171,7 @@ class AsyncConnectionTest {
     fun `stores event after send failure`() {
         // given
         val ev = mock<SentryEvent>()
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(true)
+        whenever(fixture.transportGate.isConnected).thenReturn(true)
         whenever(fixture.transport.send(any<SentryEvent>())).thenThrow(IOException())
 
         // when
@@ -191,7 +191,7 @@ class AsyncConnectionTest {
     fun `stores session after send failure`() {
         // given
         val envelope = SentryEnvelope.fromSession(fixture.sentryOptions.serializer, createSession())
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(true)
+        whenever(fixture.transportGate.isConnected).thenReturn(true)
         whenever(fixture.transport.send(any<SentryEnvelope>())).thenThrow(IOException())
 
         // when
@@ -267,7 +267,7 @@ class AsyncConnectionTest {
 
         whenever(fixture.transport.isRetryAfter(eq("event"))).thenReturn(false)
         whenever(fixture.transport.isRetryAfter(eq("session"))).thenReturn(true)
-        whenever(fixture.transportGate.isSendingAllowed).thenReturn(true)
+        whenever(fixture.transportGate.isConnected).thenReturn(true)
         whenever(fixture.transport.send(any<SentryEnvelope>())).thenReturn(TransportResult.success())
         fixture.getSUT().send(envelope)
         verify(fixture.transport).send(check<SentryEnvelope> {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
renaming transport gate method


## :bulb: Motivation and Context
`isSendingAllowed()` seems to be related to our RetryAfter impl., but actually this checks wether if the device is online or not, so `isConnected` would be better.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
