### PR TITLE
logging envelopes path when possible instead of nullable id

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/EnvelopeSender.java
+++ b/sentry-core/src/main/java/io/sentry/core/EnvelopeSender.java
@@ -6,6 +6,7 @@ import static io.sentry.core.cache.SessionCache.PREFIX_CURRENT_SESSION_FILE;
 import io.sentry.core.hints.Flushable;
 import io.sentry.core.hints.Retryable;
 import io.sentry.core.hints.SubmissionResult;
+import io.sentry.core.util.CollectionUtils;
 import io.sentry.core.util.Objects;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -93,7 +94,10 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
 
   private void processEnvelope(final @NotNull SentryEnvelope envelope, final @Nullable Object hint)
       throws IOException {
-    logger.log(SentryLevel.DEBUG, "Envelope for event Id: %s", envelope.getHeader().getEventId());
+    logger.log(
+        SentryLevel.DEBUG,
+        "Processing Envelope with %d item(s)",
+        CollectionUtils.size(envelope.getItems()));
     int items = 0;
     for (final SentryEnvelopeItem item : envelope.getItems()) {
       items++;
@@ -174,8 +178,7 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
         // without the event that created it isn't useful)
         logger.log(
             SentryLevel.WARNING,
-            "Envelope for event Id: %s had a failed capture at item %d. No more items will be sent.",
-            envelope.getHeader().getEventId(),
+            "Envelope had a failed capture at item %d. No more items will be sent.",
             items);
         break;
       }

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -97,7 +97,7 @@ public final class SessionCache implements IEnvelopeCache {
 
     if (hint instanceof SessionStart) {
       if (currentSessionFile.exists()) {
-        options.getLogger().log(WARNING, "Current envelope is not ended, we'd need to end it.");
+        options.getLogger().log(WARNING, "Current session is not ended, we'd need to end it.");
 
         try (final Reader reader =
             new BufferedReader(
@@ -228,7 +228,7 @@ public final class SessionCache implements IEnvelopeCache {
     } else {
       options
           .getLogger()
-          .log(INFO, "Current envelope is empty %s", envelope.getHeader().getEventId());
+          .log(INFO, "Current envelope %s is empty", currentSessionFile.getAbsolutePath());
     }
   }
 
@@ -237,10 +237,7 @@ public final class SessionCache implements IEnvelopeCache {
     if (file.exists()) {
       options
           .getLogger()
-          .log(
-              DEBUG,
-              "Overwriting envelope to offline storage: %s",
-              envelope.getHeader().getEventId());
+          .log(DEBUG, "Overwriting envelope to offline storage: %s", file.getAbsolutePath());
       file.delete();
     }
 
@@ -250,10 +247,7 @@ public final class SessionCache implements IEnvelopeCache {
     } catch (Exception e) {
       options
           .getLogger()
-          .log(
-              ERROR,
-              "Error writing Envelope to offline storage: %s",
-              envelope.getHeader().getEventId());
+          .log(ERROR, "Error writing Envelope %s to offline storage", file.getAbsolutePath());
     }
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
@@ -285,17 +285,9 @@ public final class AsyncConnection implements Closeable, Connection {
       TransportResult result = this.failedResult;
       try {
         result = flush();
-        options
-            .getLogger()
-            .log(SentryLevel.DEBUG, "Envelope flushed: %s", envelope.getHeader().getEventId());
+        options.getLogger().log(SentryLevel.DEBUG, "Envelope flushed");
       } catch (Exception e) {
-        options
-            .getLogger()
-            .log(
-                SentryLevel.ERROR,
-                e,
-                "Envelope submission failed: %s",
-                envelope.getHeader().getEventId());
+        options.getLogger().log(SentryLevel.ERROR, e, "Envelope submission failed");
         throw e;
       } finally {
         if (hint instanceof SubmissionResult) {

--- a/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
@@ -206,9 +206,7 @@ public class HttpTransport implements ITransport {
 
       // need to also close the input stream of the connection
       connection.getInputStream().close();
-      options
-          .getLogger()
-          .log(DEBUG, "Envelope sent %s successfully.", envelope.getHeader().getEventId());
+      options.getLogger().log(DEBUG, "Envelope sent successfully.");
       return TransportResult.success();
     } catch (IOException e) {
       try {
@@ -218,11 +216,7 @@ public class HttpTransport implements ITransport {
         if (responseCode == HttpURLConnection.HTTP_FORBIDDEN) {
           options
               .getLogger()
-              .log(
-                  DEBUG,
-                  "Envelope '"
-                      + envelope.getHeader().getEventId()
-                      + "' was rejected by the Sentry server due to a filter.");
+              .log(DEBUG, "Envelope was rejected by the Sentry server due to a filter.");
         }
         logErrorInPayload(connection);
         return TransportResult.error(responseCode);

--- a/sentry-core/src/main/java/io/sentry/core/util/CollectionUtils.java
+++ b/sentry-core/src/main/java/io/sentry/core/util/CollectionUtils.java
@@ -1,0 +1,28 @@
+package io.sentry.core.util;
+
+import java.util.Collection;
+import org.jetbrains.annotations.ApiStatus;
+
+/** Util class for Collections */
+public final class CollectionUtils {
+
+  @ApiStatus.Internal
+  private CollectionUtils() {}
+
+  /**
+   * Returns an Iterator size
+   *
+   * @param data the Iterable
+   * @return iterator size
+   */
+  public static int size(Iterable<?> data) {
+    if (data instanceof Collection) {
+      return ((Collection<?>) data).size();
+    }
+    int counter = 0;
+    for (Object ignored : data) {
+      counter++;
+    }
+    return counter;
+  }
+}

--- a/sentry-core/src/test/java/io/sentry/core/cache/SessionCacheTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/cache/SessionCacheTest.kt
@@ -177,8 +177,6 @@ class SessionCacheTest {
     fun `when session start and current file already exist, close session and start a new one`() {
         val cache = fixture.getSUT()
 
-        val file = File(fixture.options.sessionsPath!!)
-
         val envelope = SentryEnvelope.fromSession(fixture.serializer, createSession())
         cache.store(envelope, SessionStartHint())
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
logging envelopes path when possible instead of nullable id


## :bulb: Motivation and Context
envelopes that don't have an `id` would log as `null` which is not useful at all.


## :green_heart: How did you test it?
running it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
