### PR TITLE
fix racey ANR integration

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -28,7 +28,7 @@ public final class AnrIntegration implements Integration, Closeable {
 
   private @Nullable SentryOptions options;
 
-  private static final @NotNull Object sessionLock = new Object();
+  private static final @NotNull Object watchDogLock = new Object();
 
   @Override
   public final void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
@@ -42,7 +42,7 @@ public final class AnrIntegration implements Integration, Closeable {
         .log(SentryLevel.DEBUG, "AnrIntegration enabled: %s", options.isAnrEnabled());
 
     if (options.isAnrEnabled()) {
-      synchronized (sessionLock) {
+      synchronized (watchDogLock) {
         if (anrWatchDog == null) {
           options
               .getLogger()
@@ -88,7 +88,7 @@ public final class AnrIntegration implements Integration, Closeable {
 
   @Override
   public void close() throws IOException {
-    synchronized (sessionLock) {
+    synchronized (watchDogLock) {
       if (anrWatchDog != null) {
         anrWatchDog.interrupt();
         anrWatchDog = null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -20,7 +20,12 @@ import org.jetbrains.annotations.TestOnly;
  */
 public final class AnrIntegration implements Integration, Closeable {
 
-  private static ANRWatchDog anrWatchDog;
+  /**
+   * Responsible for watching UI thread. being static to avoid multiple instances running at the
+   * same time.
+   */
+  private static @Nullable ANRWatchDog anrWatchDog;
+
   private @Nullable SentryOptions options;
 
   private static final @NotNull Object sessionLock = new Object();
@@ -61,7 +66,10 @@ public final class AnrIntegration implements Integration, Closeable {
   }
 
   @TestOnly
-  void reportANR(IHub hub, final @NotNull ILogger logger, ApplicationNotResponding error) {
+  void reportANR(
+      final @NotNull IHub hub,
+      final @NotNull ILogger logger,
+      final @NotNull ApplicationNotResponding error) {
     logger.log(SentryLevel.INFO, "ANR triggered with message: %s", error.getMessage());
 
     Mechanism mechanism = new Mechanism();
@@ -73,6 +81,7 @@ public final class AnrIntegration implements Integration, Closeable {
   }
 
   @TestOnly
+  @Nullable
   ANRWatchDog getANRWatchDog() {
     return anrWatchDog;
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
@@ -26,7 +26,7 @@ class AnrIntegrationTest {
         val hub = mock<IHub>()
         integration.register(hub, options)
         assertNotNull(integration.anrWatchDog)
-        assertTrue(integration.anrWatchDog.isAlive)
+        assertTrue((integration.anrWatchDog as ANRWatchDog).isAlive)
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix racey ANR integration.


## :bulb: Motivation and Context
if different threads add an AnrIntegration and close it, it can be racey as there's a global static field.

## :green_heart: How did you test it?
ran unit tests and debugging it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
