### PR TITLE
add auto session tracking flag

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -66,7 +66,7 @@ final class AndroidOptionsInitializer {
     options.addIntegration(new NdkIntegration());
     options.addIntegration(EnvelopeFileObserverIntegration.getOutboxFileObserver(envelopeReader));
     options.addIntegration(new AnrIntegration());
-    options.addIntegration(new SessionTrackingIntegration());
+    options.addIntegration(new AutoSessionTrackingIntegration());
 
     readDefaultOptionValues(options, context);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AutoSessionTrackingIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AutoSessionTrackingIntegration.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
-public final class SessionTrackingIntegration implements Integration, Closeable {
+public final class AutoSessionTrackingIntegration implements Integration, Closeable {
 
   @TestOnly @Nullable LifecycleWatcher watcher;
 
@@ -27,14 +27,14 @@ public final class SessionTrackingIntegration implements Integration, Closeable 
         .getLogger()
         .log(
             SentryLevel.DEBUG,
-            "SessionTrackingIntegration enabled: %s",
-            options.isEnableSessionTracking());
+            "AutoSessionTrackingIntegration enabled: %s",
+            options.isEnableAutoSessionTracking());
 
-    if (options.isEnableSessionTracking()) {
+    if (options.isEnableAutoSessionTracking()) {
       watcher = new LifecycleWatcher(hub, options.getSessionTrackingIntervalMillis());
       ProcessLifecycleOwner.get().getLifecycle().addObserver(watcher);
 
-      options.getLogger().log(SentryLevel.DEBUG, "SessionTrackingIntegration installed.");
+      options.getLogger().log(SentryLevel.DEBUG, "AutoSessionTrackingIntegration installed.");
     }
   }
 
@@ -44,7 +44,7 @@ public final class SessionTrackingIntegration implements Integration, Closeable 
       ProcessLifecycleOwner.get().getLifecycle().removeObserver(watcher);
       watcher = null;
       if (options != null) {
-        options.getLogger().log(SentryLevel.DEBUG, "SessionTrackingIntegration removed.");
+        options.getLogger().log(SentryLevel.DEBUG, "AutoSessionTrackingIntegration removed.");
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -30,6 +30,8 @@ final class ManifestMetadataReader {
   static final String RELEASE = "io.sentry.release";
   static final String ENVIRONMENT = "io.sentry.environment";
   static final String SESSION_TRACKING_ENABLE = "io.sentry.session-tracking.enable";
+  static final String AUTO_SESSION_TRACKING_ENABLE = "io.sentry.session-tracking.auto.enable";
+
   static final String SESSION_TRACKING_TIMEOUT_INTERVAL_MILLIS =
       "io.sentry.session-tracking.timeout-interval-millis";
 
@@ -72,6 +74,21 @@ final class ManifestMetadataReader {
             .getLogger()
             .log(SentryLevel.DEBUG, "sessionTrackingEnabled read: %s", sessionTrackingEnabled);
         options.setEnableSessionTracking(sessionTrackingEnabled);
+
+        final boolean autoSessionTrackingEnabled =
+            metadata.getBoolean(
+                AUTO_SESSION_TRACKING_ENABLE, options.isEnableAutoSessionTracking());
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "autoSessionTrackingEnabled read: %s",
+                autoSessionTrackingEnabled);
+        options.setEnableAutoSessionTracking(autoSessionTrackingEnabled);
+
+        if (options.isEnableAutoSessionTracking()) {
+          options.setEnableSessionTracking(true);
+        }
 
         if (options.getSampleRate() == null) {
           Double sampleRate = metadata.getDouble(SAMPLE_RATE, -1);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AutoSessionTrackingIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AutoSessionTrackingIntegrationTest.kt
@@ -6,9 +6,9 @@ import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-class SessionTrackingIntegrationTest {
+class AutoSessionTrackingIntegrationTest {
 
-    private val integration = SessionTrackingIntegration()
+    private val integration = AutoSessionTrackingIntegration()
 
     @Test
     fun `When SessionTracking is enabled, lifecycle watcher should be started`() {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -205,4 +205,49 @@ class ManifestMetadataReaderTest {
         // Assert
         assertEquals(1000.toLong(), options.anrTimeoutIntervalMillis)
     }
+
+    @Test
+    fun `applyMetadata reads auto session tracking and keep default value if not found`() {
+        // Arrange
+        val options = SentryAndroidOptions()
+        val bundle = Bundle()
+        val mockContext = ContextUtilsTest.mockMetaData(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(mockContext, options)
+
+        // Assert
+        assertFalse(options.isEnableAutoSessionTracking)
+    }
+
+    @Test
+    fun `applyMetadata reads auto session tracking to options`() {
+        // Arrange
+        val options = SentryAndroidOptions()
+        val bundle = Bundle()
+        val mockContext = ContextUtilsTest.mockMetaData(metaData = bundle)
+        bundle.putBoolean(ManifestMetadataReader.AUTO_SESSION_TRACKING_ENABLE, true)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(mockContext, options)
+
+        // Assert
+        assertTrue(options.isEnableAutoSessionTracking)
+    }
+
+    @Test
+    fun `applyMetadata reads auto session tracking to options and overwrites auto session if disabled`() {
+        // Arrange
+        val options = SentryAndroidOptions()
+        val bundle = Bundle()
+        val mockContext = ContextUtilsTest.mockMetaData(metaData = bundle)
+        bundle.putBoolean(ManifestMetadataReader.AUTO_SESSION_TRACKING_ENABLE, true)
+        bundle.putBoolean(ManifestMetadataReader.SESSION_TRACKING_ENABLE, false)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(mockContext, options)
+
+        // Assert
+        assertTrue(options.isEnableSessionTracking)
+    }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -157,8 +157,14 @@ public class SentryOptions {
    */
   private boolean attachStacktrace;
 
-  /** Whether to enable automatic session tracking. */
+  /** Whether to enable session tracking. */
   private boolean enableSessionTracking;
+
+  /**
+   * Whether to enable automatic session tracking. enableAutoSessionTracking overwrites
+   * enableSessionTracking.
+   */
+  private boolean enableAutoSessionTracking;
 
   /**
    * The session tracking interval in millis. This is the interval to end a session if the App goes
@@ -673,7 +679,7 @@ public class SentryOptions {
   /**
    * Returns if the session tracking is enabled or not
    *
-   * @return trye if enabled or false otherwise
+   * @return true if enabled or false otherwise
    */
   public boolean isEnableSessionTracking() {
     return enableSessionTracking;
@@ -778,6 +784,24 @@ public class SentryOptions {
    */
   public void setFlushTimeoutMillis(long flushTimeoutMillis) {
     this.flushTimeoutMillis = flushTimeoutMillis;
+  }
+
+  /**
+   * Returns if the automatic session tracking is enabled or not
+   *
+   * @return true if enabled or false otherwise
+   */
+  public boolean isEnableAutoSessionTracking() {
+    return enableAutoSessionTracking;
+  }
+
+  /**
+   * Enable or disable the automatic session tracking
+   *
+   * @param enableAutoSessionTracking true if enabled or false otherwise
+   */
+  public void setEnableAutoSessionTracking(boolean enableAutoSessionTracking) {
+    this.enableAutoSessionTracking = enableAutoSessionTracking;
   }
 
   /** The BeforeSend callback */

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -58,8 +58,8 @@
 <!--    how to enable session tracking-->
     <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />
 
-<!--    how to disable auto session tracking-->
-    <meta-data android:name="io.sentry.session-tracking.auto.enable" android:value="false" />
+<!--    how to enable auto session tracking integration-->
+    <meta-data android:name="io.sentry.session-tracking.auto.enable" android:value="true" />
 
 <!--    how to set an environment-->
 <!--    <meta-data android:name="io.sentry.environment" android:value="debug" />-->

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -58,6 +58,9 @@
 <!--    how to enable session tracking-->
     <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />
 
+<!--    how to disable auto session tracking-->
+    <meta-data android:name="io.sentry.session-tracking.auto.enable" android:value="false" />
+
 <!--    how to set an environment-->
 <!--    <meta-data android:name="io.sentry.environment" android:value="debug" />-->
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
add auto session tracking flag


## :bulb: Motivation and Context
we have a single flag to control 2 behavior.
1 is to enable session tracking at all.
2 is to enable the automatic session tracking integration.

it is a use case where one wants to start and end a session manually and to not do it automatically, this flag allows that.

## :green_heart: How did you test it?
unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
