### PR TITLE
Avoid getting a threadlocal twice.

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -35,9 +35,10 @@ public final class Sentry {
     }
     IHub hub = currentHub.get();
     if (hub == null) {
-      currentHub.set(mainHub.clone());
+      hub = mainHub.clone();
+      currentHub.set(hub);
     }
-    return currentHub.get();
+    return hub;
   }
 
   /**


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Avoiding the extraneous `ThreadLocal.get()` is quite easy in `currentHub()` so we
should not do it.

## :bulb: Motivation and Context
`currentHub()` is a hotspot method (at least within the context of Sentry) and `ThreadLocal.get()` involves a map lookup (the more thread locals there are in the current thread, the
more expensive that is and the number of thread locals in the current
thread is out of our control).

## :green_heart: How did you test it?
By thinking hard :smile: 

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
