### PR TITLE
Make SentryEvent.getThrowable() public.

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
@@ -64,7 +64,7 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     return (Date) timestamp.clone();
   }
 
-  Throwable getThrowable() {
+  public Throwable getThrowable() {
     return throwable;
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
`$TITLE`

## :bulb: Motivation and Context
Custom event processors might want to access it the same way the main event processor. It also makes testing easier/possible (to make sure that integrations set it properly).


## :green_heart: How did you test it?
NA

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
