### PR TITLE
avoid crash if NDK throws UnsatisfiedLinkError

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -19,8 +19,7 @@ public final class NdkIntegration implements Integration {
     options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration enabled: %s", enabled);
 
     // Note: `hub` isn't used here because the NDK integration writes files to disk which are picked
-    // up by another
-    // integration. The NDK directory watching must happen before this integration runs.
+    // up by another integration (EnvelopeFileObserverIntegration).
     if (enabled) {
       try {
         Class<?> cls = Class.forName("io.sentry.android.ndk.SentryNdk");
@@ -34,7 +33,12 @@ public final class NdkIntegration implements Integration {
       } catch (ClassNotFoundException e) {
         options.setEnableNdk(false);
         options.getLogger().log(SentryLevel.ERROR, "Failed to load SentryNdk.", e);
-      } catch (Exception e) {
+      } catch (UnsatisfiedLinkError e) {
+        options.setEnableNdk(false);
+        options
+            .getLogger()
+            .log(SentryLevel.ERROR, "Failed to load (UnsatisfiedLinkError) SentryNdk.", e);
+      } catch (Throwable e) {
         options.setEnableNdk(false);
         options.getLogger().log(SentryLevel.ERROR, "Failed to initialize SentryNdk.", e);
       }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
avoid crash if NDK throws UnsatisfiedLinkError.


## :bulb: Motivation and Context
While this doesn't fix #341 it might help till we get there.


## :green_heart: How did you test it?
threw UnsatisfiedLinkError myself

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
consider https://github.com/KeepSafe/ReLinker as it's recommended in the Android official docs anyway.