### PR TITLE
change integration order for cached outbox events

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/DirectoryProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/DirectoryProcessor.java
@@ -22,7 +22,7 @@ abstract class DirectoryProcessor {
     this.flushTimeoutMillis = flushTimeoutMillis;
   }
 
-  void processDirectory(@NotNull File directory) {
+  public void processDirectory(@NotNull File directory) {
     try {
       if (!directory.exists()) {
         logger.log(

--- a/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendCachedEventFireAndForgetIntegration.java
@@ -9,15 +9,15 @@ public final class SendCachedEventFireAndForgetIntegration implements Integratio
 
   private final SendFireAndForgetFactory factory;
 
-  interface SendFireAndForget {
+  public interface SendFireAndForget {
     void send();
   }
 
-  interface SendFireAndForgetFactory {
+  public interface SendFireAndForgetFactory {
     SendFireAndForget create(IHub hub, SentryOptions options);
   }
 
-  SendCachedEventFireAndForgetIntegration(SendFireAndForgetFactory factory) {
+  public SendCachedEventFireAndForgetIntegration(SendFireAndForgetFactory factory) {
     this.factory = factory;
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -834,29 +834,6 @@ public class SentryOptions {
                 return null;
               }
             }));
-    // Send cache envelopes from NDK
-    integrations.add(
-        new SendCachedEventFireAndForgetIntegration(
-            (hub, options) -> {
-              EnvelopeSender envelopeSender =
-                  new EnvelopeSender(
-                      hub,
-                      new EnvelopeReader(), // TODO: add a getEnvelopeReader() to ISerializer()
-                      options.getSerializer(),
-                      logger,
-                      options.getFlushTimeoutMillis());
-              if (options.getOutboxPath() != null) {
-                File outbox = new File(options.getOutboxPath());
-                return () -> envelopeSender.processDirectory(outbox);
-              } else {
-                options
-                    .getLogger()
-                    .log(
-                        SentryLevel.WARNING,
-                        "No outbox dir path is defined in options, discarding EnvelopeSender.");
-                return null;
-              }
-            }));
 
     //     send cached sessions
     integrations.add(


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
change integration order for cached outbox events.


## :bulb: Motivation and Context
as sentry-native move files around on init. and the outbox file observer now is inited after the NDK integration.
This integration also should be executed afterwards, so hard crashes will be in place and ready to be sent.
I've needed to make DirectoryProcessor public.


## :green_heart: How did you test it?
running and testing it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
