### PR TITLE
session should be exited state if state is ok

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Session.java
+++ b/sentry-core/src/main/java/io/sentry/core/Session.java
@@ -166,10 +166,6 @@ public final class Session {
   /** Updated the session status based on status and errorcount */
   private void updateStatus() {
     // at this state it might be Crashed already, so we don't check for it.
-    if (status == State.Ok && errorCount.get() > 0) {
-      status = State.Abnormal;
-    }
-
     if (status == State.Ok) {
       status = State.Exited;
     }

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -135,6 +135,9 @@ public final class SessionCache implements IEnvelopeCache {
                         crashMarkerFile.getAbsolutePath());
               }
               session.update(Session.State.Crashed, null, true);
+            } else {
+              // I don't know what happened, it's not a NDK crash, let's mark it as Abnormal
+              session.update(Session.State.Abnormal, null, false);
             }
             session.end(timestamp);
             final SentryEnvelope fromSession = SentryEnvelope.fromSession(serializer, session);

--- a/sentry-core/src/test/java/io/sentry/core/SessionTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SessionTest.kt
@@ -54,14 +54,14 @@ class SessionTest {
     }
 
     @Test
-    fun `when ending a session, if status is ok and has errorCount, mark it as abnormal`() {
+    fun `when ending a session, if status is ok, mark it as exited`() {
         val user = User().apply {
             ipAddress = "127.0.0.1"
         }
         val session = createSession(user)
         session.update(null, null, true)
         session.end()
-        assertEquals(Session.State.Abnormal, session.status)
+        assertEquals(Session.State.Exited, session.status)
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
a session should be ended with an exited state.


## :bulb: Motivation and Context
the session was being ended always with abnormal if errorCount was > 0.
if there's an open session that should not be there and there's no ndk marker file, then it should be abnormal.

## :green_heart: How did you test it?
unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
