### PR TITLE
if theres a left over session file and its crashed, we should not overwrite its state

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -136,8 +136,14 @@ public final class SessionCache implements IEnvelopeCache {
               }
               session.update(Session.State.Crashed, null, true);
             } else {
-              // I don't know what happened, it's not a NDK crash, let's mark it as Abnormal
-              session.update(Session.State.Abnormal, null, false);
+              // We don't know what happened, it's not a NDK crash nor a Crashed state, let's mark
+              // it as Abnormal
+              Session.State state = Session.State.Abnormal;
+              if (session.getStatus() != null
+                  && Session.State.Crashed.equals(session.getStatus())) {
+                state = null; // keep as it is
+              }
+              session.update(state, null, false);
             }
             session.end(timestamp);
             final SentryEnvelope fromSession = SentryEnvelope.fromSession(serializer, session);

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -136,7 +136,8 @@ public final class SessionCache implements IEnvelopeCache {
               }
               session.update(Session.State.Crashed, null, true);
             } else {
-              // We don't know what happened, it's not a NDK crash nor a Crashed state, let's mark
+              // We don't know what happened, it's not a NDK crash nor a normal crashed shutdown,
+              // let's mark
               // it as Abnormal
               Session.State state = Session.State.Abnormal;
               if (session.getStatus() != null

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -137,8 +137,7 @@ public final class SessionCache implements IEnvelopeCache {
               session.update(Session.State.Crashed, null, true);
             } else {
               // We don't know what happened, it's not a NDK crash nor a normal crashed shutdown,
-              // let's mark
-              // it as Abnormal
+              // let's mark it as Abnormal
               Session.State state = Session.State.Abnormal;
               if (session.getStatus() != null
                   && Session.State.Crashed.equals(session.getStatus())) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
if there's a leftover session file and its crashed, we should not overwrite its state


## :bulb: Motivation and Context
if you are killing the app all the time via IDE or even changing the normal shutdown of the App, it might happen that a session is crashed and not sent yet, on App. restart, it's gonna be marked as abnormal, but it shouldn't if it's crashed, we should trust that file and send it as it is.


## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
