### PR TITLE
check for androidx availability on runtime

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SessionTrackingIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SessionTrackingIntegration.java
@@ -31,10 +31,21 @@ public final class SessionTrackingIntegration implements Integration, Closeable 
             options.isEnableSessionTracking());
 
     if (options.isEnableSessionTracking()) {
-      watcher = new LifecycleWatcher(hub, options.getSessionTrackingIntervalMillis());
-      ProcessLifecycleOwner.get().getLifecycle().addObserver(watcher);
+      try {
+        Class.forName("androidx.lifecycle.DefaultLifecycleObserver");
+        Class.forName("androidx.lifecycle.ProcessLifecycleOwner");
+        watcher = new LifecycleWatcher(hub, options.getSessionTrackingIntervalMillis());
+        ProcessLifecycleOwner.get().getLifecycle().addObserver(watcher);
 
-      options.getLogger().log(SentryLevel.DEBUG, "SessionTrackingIntegration installed.");
+        options.getLogger().log(SentryLevel.DEBUG, "SessionTrackingIntegration installed.");
+      } catch (ClassNotFoundException e) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.INFO,
+                "androidx.lifecycle is not available, SessionTrackingIntegration won't be installed",
+                e);
+      }
     }
   }
 

--- a/sentry-sample/build.gradle.kts
+++ b/sentry-sample/build.gradle.kts
@@ -72,7 +72,8 @@ dependencies {
 
 //    how to exclude androidx if release health feature is disabled
 //    implementation(project(":sentry-android")) {
-//        exclude(group = "androidx.lifecycle")
+//        exclude(group = "androidx.lifecycle", module = "lifecycle-process")
+//        exclude(group = "androidx.lifecycle", module = "lifecycle-common-java8")
 //    }
 
     implementation(Config.Libs.appCompat)

--- a/sentry-sample/build.gradle.kts
+++ b/sentry-sample/build.gradle.kts
@@ -70,6 +70,11 @@ dependencies {
 
     implementation(project(":sentry-android"))
 
+//    how to exclude androidx if release health feature is disabled
+//    implementation(project(":sentry-android")) {
+//        exclude(group = "androidx.lifecycle")
+//    }
+
     implementation(Config.Libs.appCompat)
 
     // debugging purpose


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
check for androidx availability on runtime


## :bulb: Motivation and Context
if you don't want to use the release health feature, you actually can exclude it.
just to avoid an error if you have enabled it and can't use androidx, we check on runtime via reflection.


## :green_heart: How did you test it?
running it/build.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
