### PR TITLE
update current session on session start after deleting previous session

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -153,9 +153,8 @@ public final class SessionCache implements IEnvelopeCache {
         } catch (IOException e) {
           options.getLogger().log(SentryLevel.ERROR, "Error processing session.", e);
         }
-      } else {
-        updateCurrentSession(currentSessionFile, envelope);
       }
+      updateCurrentSession(currentSessionFile, envelope);
     }
 
     if (hint instanceof SessionUpdate) {

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -153,6 +153,10 @@ public final class SessionCache implements IEnvelopeCache {
         } catch (IOException e) {
           options.getLogger().log(SentryLevel.ERROR, "Error processing session.", e);
         }
+
+        if (!currentSessionFile.delete()) {
+          options.getLogger().log(WARNING, "Failed to delete the current session file.");
+        }
       }
       updateCurrentSession(currentSessionFile, envelope);
     }

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -154,6 +154,8 @@ public final class SessionCache implements IEnvelopeCache {
           options.getLogger().log(SentryLevel.ERROR, "Error processing session.", e);
         }
 
+        // at this point the leftover session and its current session file already became a new envelope file to be sent
+        // so deleting it as the new session will take place.
         if (!currentSessionFile.delete()) {
           options.getLogger().log(WARNING, "Failed to delete the current session file.");
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
update current session on session start after deleting the previous session.


## :bulb: Motivation and Context
when starting a new session, if there's a leftover session, we end it and start a new one, even in this case, we should flush the new session to the current session file.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
