### PR TITLE
check external storage size even if its read only

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -675,8 +675,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private boolean isExternalStorageMounted() {
-    return (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())
-            || Environment.MEDIA_MOUNTED_READ_ONLY.equals(Environment.getExternalStorageState()))
+    final String storageState = Environment.getExternalStorageState();
+    return (Environment.MEDIA_MOUNTED.equals(storageState)
+            || Environment.MEDIA_MOUNTED_READ_ONLY.equals(storageState))
         && !Environment.isExternalStorageEmulated();
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -675,7 +675,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private boolean isExternalStorageMounted() {
-    return Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
+    return (Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())
+            || Environment.MEDIA_MOUNTED_READ_ONLY.equals(Environment.getExternalStorageState()))
         && !Environment.isExternalStorageEmulated();
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
check external storage size even if its read only


## :bulb: Motivation and Context
if external storage size was read-only, it was not able to get external storage stats


## :green_heart: How did you test it?
running it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
