### PR TITLE
fix wrong check for cellular network capability

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/util/ConnectivityChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/util/ConnectivityChecker.java
@@ -98,7 +98,7 @@ public final class ConnectivityChecker {
       if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
         return "ethernet";
       }
-      if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+      if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
         return "cellular";
       }
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix the wrong check for cellular network capability


## :bulb: Motivation and Context
when the device was connected thru a cellular network, the connection type was null


## :green_heart: How did you test it?
running it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
