### PR TITLE
exceptions should be sorted oldest to newest

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryExceptionFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryExceptionFactory.java
@@ -100,7 +100,7 @@ final class SentryExceptionFactory {
   /**
    * Transforms a {@link Throwable} into a Queue of {@link SentryException}.
    *
-   * <p>Exceptions are stored in the queue from the most recent one to the oldest one.
+   * <p>Multiple values represent chained exceptions and should be sorted oldest to newest.
    *
    * @param throwable throwable to transform in a queue of exceptions.
    * @return a queue of exception with StackTrace.
@@ -130,7 +130,7 @@ final class SentryExceptionFactory {
       }
 
       SentryException exception = getSentryException(currentThrowable, exceptionMechanism, thread);
-      exceptions.add(exception);
+      exceptions.addFirst(exception);
       currentThrowable = currentThrowable.getCause();
     }
 

--- a/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryExceptionFactoryTest.kt
@@ -41,12 +41,12 @@ class SentryExceptionFactoryTest {
     }
 
     @Test
-    fun `when exception has a cause, ensure conversion queue keeps order`() {
+    fun `when exception is nested, it should be sorted oldest to newest`() {
         val exception = Exception("message", Exception("cause"))
         val queue = sut.extractExceptionQueue(exception)
 
-        assertEquals("message", queue.first.value)
-        assertEquals("cause", queue.last.value)
+        assertEquals("cause", queue.first.value)
+        assertEquals("message", queue.last.value)
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
exceptions should be sorted oldest to newest
Fix #363

## :bulb: Motivation and Context
Probably related to getsentry/sentry/pull/18227


## :green_heart: How did you test it?
running and unit testing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
