### PR TITLE
fix: Merge loadLibrary calls for sentry-native and clean up CMake files

### DIFF
--- a/sentry-android-ndk/CMakeLists.txt
+++ b/sentry-android-ndk/CMakeLists.txt
@@ -1,16 +1,13 @@
-cmake_minimum_required(VERSION 3.4.1)
-project("sentry-android")
+cmake_minimum_required(VERSION 3.10)
+project(Sentry-Android LANGUAGES C CXX)
+
+# Add sentry-android shared library
+add_library(sentry-android SHARED src/main/jni/sentry.c)
 
 # Adding sentry-native submodule subdirectory
-add_subdirectory(${SENTRY_NATIVE_SRC})
+add_subdirectory(${SENTRY_NATIVE_SRC} sentry_build)
 
-# sentry-native submodule include path.
-include_directories(${SENTRY_NATIVE_SRC}/include)
-
-# sentry-native source code.
-file(GLOB SENTRY_ANDROID_SOURCES ${CMAKE_SOURCE_DIR}/src/main/jni/*.c)
-
-# Adding dynamic library and linking it with log and sentry-native.
-add_library("sentry-android" SHARED ${SENTRY_ANDROID_SOURCES})
-find_library(LOG_LIB log)
-target_link_libraries("sentry-android" "sentry" ${LOG_LIB})
+# Link to sentry-native
+target_link_libraries(sentry-android PRIVATE
+    $<BUILD_INTERFACE:sentry::sentry>
+)

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -9,10 +9,12 @@ public final class SentryNdk {
   private SentryNdk() {}
 
   static {
+    // On older Android versions, it was necessary to manually call "`System.loadLibrary` on all
+    // transitive dependencies before loading [the] main library."
+    // The dependencies of `libsentry.so` are currently `lib{c,m,dl,log}.so`.
+    // See https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#changes-to-library-dependency-resolution
+    System.loadLibrary("log");
     System.loadLibrary("sentry");
-  }
-
-  static {
     System.loadLibrary("sentry-android");
   }
 

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -12,7 +12,8 @@ public final class SentryNdk {
     // On older Android versions, it was necessary to manually call "`System.loadLibrary` on all
     // transitive dependencies before loading [the] main library."
     // The dependencies of `libsentry.so` are currently `lib{c,m,dl,log}.so`.
-    // See https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#changes-to-library-dependency-resolution
+    // See
+    // https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#changes-to-library-dependency-resolution
     System.loadLibrary("log");
     System.loadLibrary("sentry");
     System.loadLibrary("sentry-android");
@@ -20,13 +21,7 @@ public final class SentryNdk {
 
   private static native void initSentryNative(SentryOptions options);
 
-  private static native void verificationEventNative();
-
   public static void init(SentryOptions options) {
     initSentryNative(options);
-  }
-
-  public static void verificationEvent() {
-    verificationEventNative();
   }
 }

--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -1,8 +1,6 @@
 #include <string.h>
 #include <sentry.h>
 #include <jni.h>
-#include <malloc.h>
-#include <android/log.h>
 
 struct transport_options {
     jclass cls;

--- a/sentry-sample/CMakeLists.txt
+++ b/sentry-sample/CMakeLists.txt
@@ -1,10 +1,13 @@
-cmake_minimum_required(VERSION 3.4.1)
-project("sentry-sample")
+cmake_minimum_required(VERSION 3.10)
+project(Sentry-Sample LANGUAGES C CXX)
 
-add_subdirectory(../sentry-android-ndk/${SENTRY_NATIVE_SRC} "${CMAKE_CURRENT_BINARY_DIR}/sentry-native")
-include_directories(../sentry-android-ndk/${SENTRY_NATIVE_SRC}/include)
-
-find_library(LOG_LIB log)
 add_library(native-sample SHARED src/main/cpp/native-sample.cpp)
 
-target_link_libraries(native-sample "sentry" ${LOG_LIB})
+add_subdirectory(../sentry-android-ndk/${SENTRY_NATIVE_SRC} sentry_build)
+
+find_library(LOG_LIB log)
+
+target_link_libraries(native-sample PRIVATE
+    ${LOG_LIB}
+    $<BUILD_INTERFACE:sentry::sentry>
+)

--- a/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
@@ -6,6 +6,8 @@ public class NativeSample {
   public static native void message();
 
   static {
+    System.loadLibrary("log");
+    System.loadLibrary("sentry");
     System.loadLibrary("native-sample");
   }
 }

--- a/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
@@ -6,8 +6,6 @@ public class NativeSample {
   public static native void message();
 
   static {
-    System.loadLibrary("log");
-    System.loadLibrary("sentry");
     System.loadLibrary("native-sample");
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This loads all the non-essential-system libraries explicitly in order, to hopefully avoid dynamic linker errors such as #341 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
