### PR TITLE
ref: Rename currentEventCache to currentEnvelopeCache

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/AsyncConnection.java
@@ -117,9 +117,9 @@ public final class AsyncConnection implements Closeable, Connection {
   public void send(@NotNull SentryEnvelope envelope, final @Nullable Object hint)
       throws IOException {
     // For now no caching on envelopes
-    IEnvelopeCache currentEventCache = sessionCache;
+    IEnvelopeCache currentEnvelopeCache = sessionCache;
     if (hint instanceof Cached) {
-      currentEventCache = NoOpEnvelopeCache.getInstance();
+      currentEnvelopeCache = NoOpEnvelopeCache.getInstance();
     }
 
     // Optimize for/No allocations if no items are under 429
@@ -150,7 +150,7 @@ public final class AsyncConnection implements Closeable, Connection {
       envelope = new SentryEnvelope(envelope.getHeader(), toSend);
     }
 
-    executor.submit(new SessionSender(envelope, hint, currentEventCache));
+    executor.submit(new SessionSender(envelope, hint, currentEnvelopeCache));
   }
 
   @Override


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
In AsyncConnection.send the variable for IEnvelopeCache was named currentEventCache.
It was renamed to currentEnvelopeCache.


## :bulb: Motivation and Context
Makes the code easier to read.


## :green_heart: How did you test it?
Unit test still pass.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
None
