### PR TITLE
if retry after header has empty categories, apply retry after to all of them

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
@@ -267,7 +267,9 @@ public class HttpTransport implements ITransport {
     // X-Sentry-Rate-Limits looks like: seconds:categories:scope
     // it could have more than one scope so it looks like:
     // quota_limit, quota_limit, quota_limit
+
     // a real example: 50:transaction:key, 2700:default;event;security:organization
+    // 50::key is also a valid case, it means no categories and it should apply to all of them
     final String sentryRateLimitHeader = connection.getHeaderField("X-Sentry-Rate-Limits");
     updateRetryAfterLimits(sentryRateLimitHeader, retryAfterHeader, responseCode);
   }

--- a/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
@@ -301,20 +301,25 @@ public class HttpTransport implements ITransport {
           if (retryAfterAndCategories.length > 1) {
             final String allCategories = retryAfterAndCategories[1];
 
+            // we dont care if Date is UTC as we just add the relative seconds
+            final Date date = new Date(System.currentTimeMillis() + retryAfterMillis);
+
             if (allCategories != null && !allCategories.isEmpty()) {
               final String[] categories = allCategories.split(";", -1);
 
               for (final String catItem : categories) {
-                // we dont care if Date is UTC as we just add the relative seconds
-                sentryRetryAfterLimit.put(
-                    catItem, new Date(System.currentTimeMillis() + retryAfterMillis));
+                sentryRetryAfterLimit.put(catItem, date);
               }
             } else {
               // if categories are empty, we should apply to all the categories.
               // we do that using a `default` category as the fallback
-              sentryRetryAfterLimit.clear();
-              final Date date = new Date(System.currentTimeMillis() + retryAfterMillis);
-              sentryRetryAfterLimit.put(HTTP_RETRY_DEFAULT_CATEGORY, date);
+              for (final String catItem : sentryRetryAfterLimit.keySet()) {
+                sentryRetryAfterLimit.put(catItem, date);
+              }
+              // if 'default' category is not added yet, we add it now as a fallback
+              if (!sentryRetryAfterLimit.containsKey(HTTP_RETRY_DEFAULT_CATEGORY)) {
+                sentryRetryAfterLimit.put(HTTP_RETRY_DEFAULT_CATEGORY, date);
+              }
             }
           }
         }

--- a/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
@@ -261,7 +261,7 @@ public class HttpTransport implements ITransport {
 
   private void updateRetryAfterLimits(
       final @NotNull HttpURLConnection connection, final int responseCode) {
-    // milliseconds
+    // seconds
     final String retryAfterHeader = connection.getHeaderField("Retry-After");
 
     // X-Sentry-Rate-Limits looks like: seconds:categories:scope
@@ -312,11 +312,10 @@ public class HttpTransport implements ITransport {
               }
             } else {
               // if categories are empty, we should apply to all the categories.
-              // we do that using a `default` category as the fallback
               for (final String catItem : sentryRetryAfterLimit.keySet()) {
                 sentryRetryAfterLimit.put(catItem, date);
               }
-              // if 'default' category is not added yet, we add it now as a fallback
+              // if 'default' category is not added yet, we add it as a fallback
               if (!sentryRetryAfterLimit.containsKey(HTTP_RETRY_DEFAULT_CATEGORY)) {
                 sentryRetryAfterLimit.put(HTTP_RETRY_DEFAULT_CATEGORY, date);
               }

--- a/sentry-core/src/test/java/io/sentry/core/transport/HttpTransportTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/HttpTransportTest.kt
@@ -282,6 +282,21 @@ class HttpTransportTest {
         assertFalse(transport.isRetryAfter("security"))
     }
 
+    @Test
+    fun `When X-Sentry-Rate-Limit categories are empty, applies to all the categories`() {
+        val transport = fixture.getSUT()
+
+        whenever(fixture.connection.inputStream).thenThrow(IOException())
+        whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
+            .thenReturn("50::key")
+
+        val event = SentryEvent()
+
+        transport.send(event)
+
+        assertTrue(transport.isRetryAfter("event"))
+    }
+
     private fun createSession(): Session {
         return Session("123", User(), "env", "release")
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
if retry after header has empty categories, apply retry after to all of them.


## :bulb: Motivation and Context
the current implementation was not handling empty categories.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
