### PR TITLE
fix when PhoneStateListener is not ready for use

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
@@ -47,10 +47,16 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
     if (this.options.isEnableSystemEventBreadcrumbs()) {
       telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
       if (telephonyManager != null) {
-        listener = new PhoneStateChangeListener(hub);
-        telephonyManager.listen(listener, LISTEN_CALL_STATE);
+        try {
+          listener = new PhoneStateChangeListener(hub);
+          telephonyManager.listen(listener, LISTEN_CALL_STATE);
 
-        options.getLogger().log(SentryLevel.DEBUG, "PhoneStateBreadcrumbsIntegration installed.");
+          options.getLogger().log(SentryLevel.DEBUG, "PhoneStateBreadcrumbsIntegration installed.");
+        } catch (NullPointerException e) {
+          this.options
+              .getLogger()
+              .log(SentryLevel.INFO, e, "TelephonyManager is not ready for use.");
+        }
       } else {
         this.options.getLogger().log(SentryLevel.INFO, "TelephonyManager is not available");
       }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix when PhoneStateListener is not ready for use
probably because `Looper.myLooper()` returns null, but I can't find out how


## :bulb: Motivation and Context
java.lang.RuntimeException: Unable to create application package_here: java.lang.NullPointerException: Attempt to read from field 'android.os.MessageQueue android.os.Looper.mQueue' on a null object reference
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6465)
        at android.app.ActivityThread.access$1300(ActivityThread.java:219)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1859)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: java.lang.NullPointerException: Attempt to read from field 'android.os.MessageQueue android.os.Looper.mQueue' on a null object reference
        at android.os.Handler.<init>(Handler.java:237)
        at android.os.Handler.<init>(Handler.java:142)
        at android.telephony.PhoneStateListener.<init>(PhoneStateListener.java:420)
        at android.telephony.PhoneStateListener.<init>(PhoneStateListener.java:385)
        at io.sentry.android.core.PhoneStateBreadcrumbsIntegration$PhoneStateChangeListener.<init>(PhoneStateBreadcrumbsIntegration.java:76)
        at io.sentry.android.core.PhoneStateBreadcrumbsIntegration.register(PhoneStateBreadcrumbsIntegration.java:50)
        at io.sentry.core.Hub.<init>(Hub.java:38)
        at io.sentry.core.Sentry.init(Sentry.java:144)
        at io.sentry.core.Sentry.init(Sentry.java:92)
        at io.sentry.android.core.SentryAndroid.init(SentryAndroid.java:59)
        at io.sentry.android.core.SentryAndroid.init(SentryAndroid.java:44)


## :green_heart: How did you test it?
I didn't, could not reproduce it, but an NPE check doesn't hurt.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
