### PR TITLE
make ANR 5s by default

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -11,8 +11,8 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   private boolean anrEnabled = true;
 
-  /** ANR Timeout internal in Millis Default is 4000 = 4s Used by AnrIntegration */
-  private long anrTimeoutIntervalMillis = 4000;
+  /** ANR Timeout internal in Millis Default is 5000 = 5s Used by AnrIntegration */
+  private long anrTimeoutIntervalMillis = 5000;
 
   /** Enable or disable ANR on Debug mode Default is disabled Used by AnrIntegration */
   private boolean anrReportInDebug = false;
@@ -69,7 +69,7 @@ public final class SentryAndroidOptions extends SentryOptions {
   }
 
   /**
-   * Returns the ANR timeout internal in Millis Default is 4000 = 4s
+   * Returns the ANR timeout internal in Millis Default is 5000 = 5s
    *
    * @return the timeout in millis
    */
@@ -78,7 +78,7 @@ public final class SentryAndroidOptions extends SentryOptions {
   }
 
   /**
-   * Sets the ANR timeout internal in Millis Default is 4000 = 4s
+   * Sets the ANR timeout internal in Millis Default is 5000 = 5s
    *
    * @param anrTimeoutIntervalMillis the timeout internal in Millis
    */

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -37,8 +37,8 @@
 <!--    how to set a custom debug level-->
 <!--    <meta-data android:name="io.sentry.debug.level" android:value="info" />-->
 
-<!--    To change the time used to watch for ANR. By default it's 4 seconds (4000 below as it's in milliseconds)-->
-<!--    <meta-data android:name="io.sentry.anr.timeout-interval-millis" android:value="4000" />-->
+<!--    To change the time used to watch for ANR. By default it's 5 seconds (5000 below as it's in milliseconds)-->
+<!--    <meta-data android:name="io.sentry.anr.timeout-interval-millis" android:value="10000" />-->
 
 <!--    Raise ANR events even if the debugger is attached-->
 <!--    <meta-data android:name="io.sentry.anr.report-debug" android:value="true" />-->

--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
 <!--    <meta-data android:name="io.sentry.debug.level" android:value="info" />-->
 
 <!--    To change the time used to watch for ANR. By default it's 5 seconds (5000 below as it's in milliseconds)-->
-<!--    <meta-data android:name="io.sentry.anr.timeout-interval-millis" android:value="10000" />-->
+<!--    <meta-data android:name="io.sentry.anr.timeout-interval-millis" android:value="5000" />-->
 
 <!--    Raise ANR events even if the debugger is attached-->
 <!--    <meta-data android:name="io.sentry.anr.report-debug" android:value="true" />-->

--- a/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/MainActivity.java
@@ -55,7 +55,7 @@ public class MainActivity extends AppCompatActivity {
         .setOnClickListener(
             view -> {
               // Try cause ANR by blocking for 2.5 seconds.
-              // By default the SDK sends an event if blocked by at least 4 seconds.
+              // By default the SDK sends an event if blocked by at least 5 seconds.
               // The time was configurable (see manifest) to 1 second for demo purposes.
               // NOTE: By default it doesn't raise if the debugger is attached. That can also be
               // configured.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
make ANR 5s by default


## :bulb: Motivation and Context
ANR is very spammy sometimes and originally this was 5s by default.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
