### PR TITLE
add a DateTimeProvider for making retry after testable

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/transport/CurrentDateProvider.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/CurrentDateProvider.java
@@ -1,0 +1,18 @@
+package io.sentry.core.transport;
+
+import java.util.Date;
+import org.jetbrains.annotations.NotNull;
+
+/** Date Provider to make the Transport unit testable */
+final class CurrentDateProvider implements ICurrentDateProvider {
+
+  @Override
+  public final @NotNull Date getCurrentDate() {
+    return new Date();
+  }
+
+  @Override
+  public final @NotNull Date getDate(long timeMillis) {
+    return new Date(timeMillis);
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/transport/CurrentDateProvider.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/CurrentDateProvider.java
@@ -3,7 +3,6 @@ package io.sentry.core.transport;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
-/** Date Provider to make the Transport unit testable */
 final class CurrentDateProvider implements ICurrentDateProvider {
 
   @Override
@@ -12,7 +11,7 @@ final class CurrentDateProvider implements ICurrentDateProvider {
   }
 
   @Override
-  public final @NotNull Date getDate(long timeMillis) {
+  public final @NotNull Date getDate(final long timeMillis) {
     return new Date(timeMillis);
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/transport/CurrentDateProvider.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/CurrentDateProvider.java
@@ -1,17 +1,9 @@
 package io.sentry.core.transport;
 
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 final class CurrentDateProvider implements ICurrentDateProvider {
 
   @Override
-  public final @NotNull Date getCurrentDate() {
-    return new Date();
-  }
-
-  @Override
-  public final @NotNull Date getDate(final long timeMillis) {
-    return new Date(timeMillis);
+  public final long getCurrentTimeMillis() {
+    return System.currentTimeMillis();
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
@@ -10,6 +10,7 @@ import io.sentry.core.ISerializer;
 import io.sentry.core.SentryEnvelope;
 import io.sentry.core.SentryEvent;
 import io.sentry.core.SentryOptions;
+import io.sentry.core.util.Objects;
 import io.sentry.core.util.StringUtils;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -81,6 +82,8 @@ public class HttpTransport implements ITransport {
 
   private static final int HTTP_RETRY_AFTER_DEFAULT_DELAY_MILLIS = 60000;
 
+  private final @NotNull ICurrentDateProvider currentDateProvider;
+
   /**
    * Constructs a new HTTP transport instance. Notably, the provided {@code requestUpdater} must set
    * the appropriate content encoding header for the {@link io.sentry.core.ISerializer} instance
@@ -101,6 +104,24 @@ public class HttpTransport implements ITransport {
       final int readTimeoutMillis,
       final boolean bypassSecurity,
       final @NotNull URL sentryUrl) {
+    this(
+        options,
+        connectionConfigurator,
+        connectionTimeoutMillis,
+        readTimeoutMillis,
+        bypassSecurity,
+        sentryUrl,
+        new CurrentDateProvider());
+  }
+
+  HttpTransport(
+      final @NotNull SentryOptions options,
+      final @NotNull IConnectionConfigurator connectionConfigurator,
+      final int connectionTimeoutMillis,
+      final int readTimeoutMillis,
+      final boolean bypassSecurity,
+      final @NotNull URL sentryUrl,
+      final @NotNull ICurrentDateProvider currentDateProvider) {
     this.proxy = options.getProxy();
     this.connectionConfigurator = connectionConfigurator;
     this.serializer = options.getSerializer();
@@ -108,6 +129,8 @@ public class HttpTransport implements ITransport {
     this.readTimeout = readTimeoutMillis;
     this.options = options;
     this.bypassSecurity = bypassSecurity;
+    this.currentDateProvider =
+        Objects.requireNonNull(currentDateProvider, "CurrentDateProvider is required.");
 
     try {
       final URI uri = sentryUrl.toURI();
@@ -183,7 +206,7 @@ public class HttpTransport implements ITransport {
   @Override
   public boolean isRetryAfter(final @NotNull String itemType) {
     final DataCategory dataCategory = getCategoryFromItemType(itemType);
-    final Date currentDate = new Date();
+    final Date currentDate = currentDateProvider.getCurrentDate();
 
     // check all categories
     final Date dateAllCategories = sentryRetryAfterLimit.get(DataCategory.All);
@@ -357,7 +380,8 @@ public class HttpTransport implements ITransport {
             final String allCategories = retryAfterAndCategories[1];
 
             // we dont care if Date is UTC as we just add the relative seconds
-            final Date date = new Date(System.currentTimeMillis() + retryAfterMillis);
+            final Date date =
+                currentDateProvider.getDate(System.currentTimeMillis() + retryAfterMillis);
 
             if (allCategories != null && !allCategories.isEmpty()) {
               final String[] categories = allCategories.split(";", -1);
@@ -385,7 +409,7 @@ public class HttpTransport implements ITransport {
     } else if (errorCode == 429) {
       final long retryAfterMillis = parseRetryAfterOrDefault(retryAfterHeader);
       // we dont care if Date is UTC as we just add the relative seconds
-      final Date date = new Date(System.currentTimeMillis() + retryAfterMillis);
+      final Date date = currentDateProvider.getDate(System.currentTimeMillis() + retryAfterMillis);
       applyRetryAfterOnlyIfLonger(DataCategory.All, date);
     }
   }

--- a/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/HttpTransport.java
@@ -206,7 +206,7 @@ public class HttpTransport implements ITransport {
   @Override
   public boolean isRetryAfter(final @NotNull String itemType) {
     final DataCategory dataCategory = getCategoryFromItemType(itemType);
-    final Date currentDate = currentDateProvider.getCurrentDate();
+    final Date currentDate = new Date(currentDateProvider.getCurrentTimeMillis());
 
     // check all categories
     final Date dateAllCategories = sentryRetryAfterLimit.get(DataCategory.All);
@@ -381,7 +381,7 @@ public class HttpTransport implements ITransport {
 
             // we dont care if Date is UTC as we just add the relative seconds
             final Date date =
-                currentDateProvider.getDate(System.currentTimeMillis() + retryAfterMillis);
+                new Date(currentDateProvider.getCurrentTimeMillis() + retryAfterMillis);
 
             if (allCategories != null && !allCategories.isEmpty()) {
               final String[] categories = allCategories.split(";", -1);
@@ -409,7 +409,7 @@ public class HttpTransport implements ITransport {
     } else if (errorCode == 429) {
       final long retryAfterMillis = parseRetryAfterOrDefault(retryAfterHeader);
       // we dont care if Date is UTC as we just add the relative seconds
-      final Date date = currentDateProvider.getDate(System.currentTimeMillis() + retryAfterMillis);
+      final Date date = new Date(currentDateProvider.getCurrentTimeMillis() + retryAfterMillis);
       applyRetryAfterOnlyIfLonger(DataCategory.All, date);
     }
   }

--- a/sentry-core/src/main/java/io/sentry/core/transport/ICurrentDateProvider.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/ICurrentDateProvider.java
@@ -2,6 +2,7 @@ package io.sentry.core.transport;
 
 import java.util.Date;
 
+/** Date Provider to make the Transport unit testable */
 interface ICurrentDateProvider {
 
   /**

--- a/sentry-core/src/main/java/io/sentry/core/transport/ICurrentDateProvider.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/ICurrentDateProvider.java
@@ -1,22 +1,12 @@
 package io.sentry.core.transport;
 
-import java.util.Date;
-
 /** Date Provider to make the Transport unit testable */
 interface ICurrentDateProvider {
 
   /**
-   * Returns the current Date (local)
+   * Returns the current time in millis
    *
-   * @return the Date
+   * @return the time in millis
    */
-  Date getCurrentDate();
-
-  /**
-   * Returns a new Date based on the given timeMillis
-   *
-   * @param timeMillis the Time in millis
-   * @return the given Date
-   */
-  Date getDate(long timeMillis);
+  long getCurrentTimeMillis();
 }

--- a/sentry-core/src/main/java/io/sentry/core/transport/ICurrentDateProvider.java
+++ b/sentry-core/src/main/java/io/sentry/core/transport/ICurrentDateProvider.java
@@ -1,0 +1,21 @@
+package io.sentry.core.transport;
+
+import java.util.Date;
+
+interface ICurrentDateProvider {
+
+  /**
+   * Returns the current Date (local)
+   *
+   * @return the Date
+   */
+  Date getCurrentDate();
+
+  /**
+   * Returns a new Date based on the given timeMillis
+   *
+   * @param timeMillis the Time in millis
+   * @return the given Date
+   */
+  Date getDate(long timeMillis);
+}

--- a/sentry-core/src/test/java/io/sentry/core/transport/HttpTransportTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/transport/HttpTransportTest.kt
@@ -16,7 +16,6 @@ import java.net.HttpURLConnection
 import java.net.Proxy
 import java.net.URI
 import java.net.URL
-import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -90,8 +89,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("Retry-After"))).thenReturn("30")
         whenever(fixture.connection.responseCode).thenReturn(429)
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 30000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val event = SentryEvent()
 
@@ -109,8 +107,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("Retry-After"))).thenReturn("30")
         whenever(fixture.connection.responseCode).thenReturn(429)
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 30000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val envelope = SentryEnvelope.fromSession(fixture.serializer, createSession())
 
@@ -159,8 +156,7 @@ class HttpTransportTest {
 
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.responseCode).thenReturn(429)
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 60000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val event = SentryEvent()
 
@@ -177,8 +173,7 @@ class HttpTransportTest {
 
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.responseCode).thenReturn(429)
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 60000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val envelope = SentryEnvelope.fromSession(fixture.serializer, createSession())
 
@@ -229,8 +224,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("50:transaction:key, 2700:default;error;security:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 50000), Date(System.currentTimeMillis() + 2700000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val event = SentryEvent()
 
@@ -248,8 +242,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("50:transaction:key, 1:default;error;security:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date(System.currentTimeMillis() + 2000))
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 50000), Date(System.currentTimeMillis() + 1000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 0, 1001)
 
         val event = SentryEvent()
 
@@ -267,8 +260,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("50:transaction:key, 2700:default;error;security:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 50000), Date(System.currentTimeMillis() + 2700000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val event = SentryEvent()
 
@@ -285,8 +277,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("1:transaction:key, 1:default;error;security:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date(System.currentTimeMillis() + 2000))
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 1000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 0, 1001)
 
         val event = SentryEvent()
 
@@ -302,8 +293,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("50::key")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date(System.currentTimeMillis()))
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 50000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val event = SentryEvent()
 
@@ -319,8 +309,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("60:default;foobar;error;security:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 60000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
 
         val event = SentryEvent()
 
@@ -335,8 +324,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("1::key, 60:default;error;security:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date(System.currentTimeMillis() + 2000), Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 1000), Date(System.currentTimeMillis() + 60000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 0, 1001)
 
         val event = SentryEvent()
 
@@ -351,8 +339,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("60:error:key, 1:error:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date(System.currentTimeMillis() + 2000), Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 60000), Date(System.currentTimeMillis() + 1000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 0, 1001)
 
         val event = SentryEvent()
 
@@ -367,8 +354,7 @@ class HttpTransportTest {
         whenever(fixture.connection.inputStream).thenThrow(IOException())
         whenever(fixture.connection.getHeaderField(eq("X-Sentry-Rate-Limits")))
             .thenReturn("1:error:key, 5:error:organization")
-        whenever(fixture.currentDateProvider.currentDate).thenReturn(Date(System.currentTimeMillis() + 2000), Date())
-        whenever(fixture.currentDateProvider.getDate(any())).thenReturn(Date(System.currentTimeMillis() + 1000), Date(System.currentTimeMillis() + 5000))
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 0, 1001)
 
         val event = SentryEvent()
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
add a DateTimeProvider for making retry after testable


## :bulb: Motivation and Context
we were using Thread.sleep(x) and this was slowing down the tests and could also become flakey, with this we can assert things properly.
thanks @philipphofmann for the code review #381 good catch.

## :green_heart: How did you test it?
unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
