### PR TITLE
enha: only set breadcrumb extras if not empty

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -200,8 +200,8 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
                 action);
           }
         }
+        breadcrumb.setData("extras", newExtras);
       }
-      breadcrumb.setData("extras", newExtras);
       breadcrumb.setLevel(SentryLevel.INFO);
       hub.addBreadcrumb(breadcrumb);
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
enha: only set breadcrumb extras if not empty


## :bulb: Motivation and Context
sending empty extras is non sense


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
