### PR TITLE
added missing getters on Breadcrumb and SentryEvent

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
+++ b/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
@@ -114,6 +114,16 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
   }
 
   /**
+   * Returns the value of data[key] or null
+   *
+   * @return the value or null
+   */
+  @Nullable
+  public Object getData(final @NotNull String key) {
+    return data.get(key);
+  }
+
+  /**
    * Sets an entry to the data's map
    *
    * @param key the key

--- a/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
@@ -193,15 +193,8 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     this.sdk = sdk;
   }
 
-  List<String> getFingerprints() {
+  public List<String> getFingerprints() {
     return fingerprint;
-  }
-
-  public boolean hasFingerprint(final @NotNull String fingerprint) {
-    if (this.fingerprint != null) {
-      return this.fingerprint.contains(fingerprint);
-    }
-    return false;
   }
 
   public void setFingerprints(List<String> fingerprint) {

--- a/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 public final class SentryEvent implements IUnknownPropertiesConsumer {
@@ -196,6 +197,13 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     return fingerprint;
   }
 
+  public boolean hasFingerprint(final @NotNull String fingerprint) {
+    if (this.fingerprint != null) {
+      return this.fingerprint.contains(fingerprint);
+    }
+    return false;
+  }
+
   public void setFingerprints(List<String> fingerprint) {
     this.fingerprint = fingerprint;
   }
@@ -229,6 +237,13 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     }
   }
 
+  public @Nullable String getTag(final @NotNull String key) {
+    if (tags != null) {
+      return tags.get(key);
+    }
+    return null;
+  }
+
   public void setTag(String key, String value) {
     if (tags == null) {
       tags = new HashMap<>();
@@ -255,6 +270,13 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     if (extra != null) {
       extra.remove(key);
     }
+  }
+
+  public @Nullable Object getExtra(final @NotNull String key) {
+    if (extra != null) {
+      return extra.get(key);
+    }
+    return null;
   }
 
   public Contexts getContexts() {
@@ -295,6 +317,13 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     if (modules != null) {
       modules.remove(key);
     }
+  }
+
+  public @Nullable String getModule(final @NotNull String key) {
+    if (modules != null) {
+      return modules.get(key);
+    }
+    return null;
   }
 
   public DebugMeta getDebugMeta() {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
added missing getters on Breadcrumb and SentryEvent


## :green_heart: How did you test it?
it was not possible to use `beforeSend` or `beforeBreadcrumb` with those fields.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
