### PR TITLE
do not add automatic and empty sensor breadcrumbs

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -84,7 +84,7 @@ public final class TempSensorBreadcrumbsIntegration
   public void onSensorChanged(SensorEvent event) {
     final float[] values = event.values;
     // return if data is not available or zero'ed
-    if (values == null || values.length == 0 || values[0] <= 0f) {
+    if (values == null || values.length == 0 || values[0] == 0f) {
       return;
     }
 
@@ -96,7 +96,7 @@ public final class TempSensorBreadcrumbsIntegration
       breadcrumb.setData("accuracy", event.accuracy);
       breadcrumb.setData("timestamp", event.timestamp);
       breadcrumb.setLevel(SentryLevel.INFO);
-      breadcrumb.setData("values", event.values);
+      breadcrumb.setData("degree", event.values[0]); // Celsius
       hub.addBreadcrumb(breadcrumb);
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -82,6 +82,12 @@ public final class TempSensorBreadcrumbsIntegration
 
   @Override
   public void onSensorChanged(SensorEvent event) {
+    final float[] values = event.values;
+    // return if data is not available or zero'ed
+    if (values == null || values.length == 0 || values[0] <= 0f) {
+      return;
+    }
+
     if (hub != null) {
       final Breadcrumb breadcrumb = new Breadcrumb();
       breadcrumb.setType("system");
@@ -90,9 +96,7 @@ public final class TempSensorBreadcrumbsIntegration
       breadcrumb.setData("accuracy", event.accuracy);
       breadcrumb.setData("timestamp", event.timestamp);
       breadcrumb.setLevel(SentryLevel.INFO);
-      if (event.values != null) {
-        breadcrumb.setData("values", event.values);
-      }
+      breadcrumb.setData("values", event.values);
       hub.addBreadcrumb(breadcrumb);
     }
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/TempSensorBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/TempSensorBreadcrumbsIntegrationTest.kt
@@ -2,6 +2,7 @@ package io.sentry.android.core
 
 import android.content.Context
 import android.hardware.Sensor
+import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import com.nhaarman.mockitokotlin2.any
@@ -14,6 +15,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.Breadcrumb
 import io.sentry.core.IHub
 import io.sentry.core.SentryLevel
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -67,8 +69,9 @@ class TempSensorBreadcrumbsIntegrationTest {
         assertNull(sut.sensorManager)
     }
 
+    @Ignore("SensorEvent.values is always null, even when mocking it")
     @Test
-    fun `When on call state received, added breadcrumb with type and category`() {
+    fun `When onSensorChanged received, add a breadcrumb with type and category`() {
         val sut = fixture.getSut()
         val options = SentryAndroidOptions()
         val hub = mock<IHub>()
@@ -80,5 +83,18 @@ class TempSensorBreadcrumbsIntegrationTest {
             assertEquals("system", it.type)
             assertEquals(SentryLevel.INFO, it.level)
         })
+    }
+
+    @Test
+    fun `When onSensorChanged received and null values, do not add a breadcrumb`() {
+        val sut = fixture.getSut()
+        val options = SentryAndroidOptions()
+        val hub = mock<IHub>()
+        sut.register(hub, options)
+        val event = mock<SensorEvent>()
+        assertNull(event.values)
+        sut.onSensorChanged(event)
+
+        verify(hub, never()).addBreadcrumb(any<Breadcrumb>())
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
do not add automatic and empty sensor breadcrumbs


## :bulb: Motivation and Context
inspired by #400


## :green_heart: How did you test it?
ran it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
find out how to avoid `@Ignore` test, tried mocking, reflection, hacking private-package but still `SensorEvent.values` is always null, maybe because of `UnsupportedAppUsage` in the ctor.