### PR TITLE
fix: set missing release, environment and dist to sentry-native options

### DIFF
--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -38,6 +38,15 @@ JNIEXPORT void JNICALL Java_io_sentry_android_ndk_SentryNdk_initSentryNative(JNI
     jmethodID is_debug_mid = (*env)->GetMethodID(env, options_cls, "isDebug", "()Z");
     g_transport_options.debug = (*env)->CallBooleanMethod(env, sentry_sdk_options, is_debug_mid);
 
+    jmethodID release_mid = (*env)->GetMethodID(env, options_cls, "getRelease", "()Ljava/lang/String;");
+    jstring release = (jstring)(*env)->CallObjectMethod(env, sentry_sdk_options, release_mid);
+
+    jmethodID environment_mid = (*env)->GetMethodID(env, options_cls, "getEnvironment", "()Ljava/lang/String;");
+    jstring environment = (jstring)(*env)->CallObjectMethod(env, sentry_sdk_options, environment_mid);
+
+    jmethodID dist_mid = (*env)->GetMethodID(env, options_cls, "getDist", "()Ljava/lang/String;");
+    jstring dist = (jstring)(*env)->CallObjectMethod(env, sentry_sdk_options, dist_mid);
+
     g_transport_options.env = env;
     g_transport_options.cls = cls;
 
@@ -56,5 +65,16 @@ JNIEXPORT void JNICALL Java_io_sentry_android_ndk_SentryNdk_initSentryNative(JNI
             options, sentry_new_function_transport(send_envelope, NULL));
     sentry_options_set_debug(options, g_transport_options.debug);
     sentry_options_set_dsn(options, (*env)->GetStringUTFChars(env, dsn, 0));
+
+    if (release != NULL) {
+        sentry_options_set_release(options, (*env)->GetStringUTFChars(env, release, 0));
+    }
+    if (environment != NULL) {
+        sentry_options_set_environment(options, (*env)->GetStringUTFChars(env, environment, 0));
+    }
+    if (dist != NULL) {
+        sentry_options_set_dist(options, (*env)->GetStringUTFChars(env, dist, 0));
+    }
+
     sentry_init(options);
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
set missing release, environment and dist to sentry-native options


## :bulb: Motivation and Context
those fields were missing on NDK hard crashes and the Android bits were not overwriting it as the app could be upgraded before restarting it.


## :green_heart: How did you test it?
ran sample.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
