### PR TITLE
fix: initing SDK on AttachBaseContext

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -49,12 +49,9 @@ final class AndroidOptionsInitializer {
       final @NotNull ILogger logger) {
     Objects.requireNonNull(context, "The context is required.");
 
-    if (!(context instanceof Application)) {
-      // if context is not an AppContext, let's try to get from getApplicationContext
-      // it returns null if ContextImpl, so let's check for nullability
-      if (context.getApplicationContext() != null) {
-        context = context.getApplicationContext();
-      }
+    // it returns null if ContextImpl, so let's check for nullability
+    if (context.getApplicationContext() != null) {
+      context = context.getApplicationContext();
     }
 
     Objects.requireNonNull(options, "The options object is required.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -48,9 +48,13 @@ final class AndroidOptionsInitializer {
       @NotNull Context context,
       final @NotNull ILogger logger) {
     Objects.requireNonNull(context, "The context is required.");
-    context =
-        Objects.requireNonNull(
-            context.getApplicationContext(), "The application context is required.");
+
+    if (!(context instanceof Application)) {
+      context =
+          Objects.requireNonNull(
+              context.getApplicationContext(), "The application context is required.");
+    }
+
     Objects.requireNonNull(options, "The options object is required.");
     Objects.requireNonNull(logger, "The ILogger object is required.");
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -50,9 +50,11 @@ final class AndroidOptionsInitializer {
     Objects.requireNonNull(context, "The context is required.");
 
     if (!(context instanceof Application)) {
-      context =
-          Objects.requireNonNull(
-              context.getApplicationContext(), "The application context is required.");
+      // if context is not an AppContext, let's try to get from getApplicationContext
+      // it returns null if ContextImpl, so let's check for nullability
+      if (context.getApplicationContext() != null) {
+        context = context.getApplicationContext();
+      }
     }
 
     Objects.requireNonNull(options, "The options object is required.");
@@ -117,7 +119,9 @@ final class AndroidOptionsInitializer {
 
     options.addIntegration(new AnrIntegration());
     options.addIntegration(new AppLifecycleIntegration());
-    if (context instanceof Application) { // just a guard check, it should be an Application
+
+    // registerActivityLifecycleCallbacks is only available if Context is an AppContext
+    if (context instanceof Application) {
       options.addIntegration(new ActivityBreadcrumbsIntegration((Application) context));
     } else {
       options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -45,14 +45,26 @@ public final class AppComponentsBreadcrumbsIntegration
             this.options.isEnableAppComponentBreadcrumbs());
 
     if (this.options.isEnableAppComponentBreadcrumbs()) {
-      context.registerComponentCallbacks(this);
-      options.getLogger().log(SentryLevel.DEBUG, "AppComponentsBreadcrumbsIntegration installed.");
+      try {
+        // if its a ContextImpl, registerComponentCallbacks can't be used
+        context.registerComponentCallbacks(this);
+        options
+            .getLogger()
+            .log(SentryLevel.DEBUG, "AppComponentsBreadcrumbsIntegration installed.");
+      } catch (Exception e) {
+        this.options.setEnableAppComponentBreadcrumbs(false);
+        options.getLogger().log(SentryLevel.INFO, e, "ComponentCallbacks2 is not available.");
+      }
     }
   }
 
   @Override
   public void close() throws IOException {
-    context.unregisterComponentCallbacks(this);
+    try {
+      // if its a ContextImpl, unregisterComponentCallbacks can't be used
+      context.unregisterComponentCallbacks(this);
+    } catch (Exception ignore) {
+    }
 
     if (options != null) {
       options.getLogger().log(SentryLevel.DEBUG, "AppComponentsBreadcrumbsIntegration removed.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -63,7 +63,7 @@ public final class AppComponentsBreadcrumbsIntegration
     try {
       // if its a ContextImpl, unregisterComponentCallbacks can't be used
       context.unregisterComponentCallbacks(this);
-    } catch (Exception ignore) {
+    } catch (Exception ignored) {
     }
 
     if (options != null) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -12,6 +12,7 @@ import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -12,9 +12,9 @@ import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 
@@ -222,12 +222,24 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
-    fun `When given Context is not an Application class and ApplicationContext is null, throw IllegalArgumentException`() {
+    fun `When given Context is not an Application class and ApplicationContext is null, keep given Context`() {
         val sentryOptions = SentryAndroidOptions()
         val mockContext = mock<Context>()
         whenever(mockContext.applicationContext).thenReturn(null)
 
-        assertFailsWith<IllegalArgumentException> { AndroidOptionsInitializer.init(sentryOptions, mockContext) }
+        AndroidOptionsInitializer.init(sentryOptions, mockContext)
+        assertNotNull(mockContext)
+    }
+
+    @Test
+    fun `When given Context is not an Application class, do not add ActivityBreadcrumbsIntegration`() {
+        val sentryOptions = SentryAndroidOptions()
+        val mockContext = mock<Context>()
+        whenever(mockContext.applicationContext).thenReturn(null)
+
+        AndroidOptionsInitializer.init(sentryOptions, mockContext)
+        val actual = sentryOptions.integrations.firstOrNull { it is ActivityBreadcrumbsIntegration }
+        assertNull(actual)
     }
 
     private fun createMockContext(): Context {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -211,7 +211,7 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
-    fun `When given Context is not an Application class, get and set ApplicationContext`() {
+    fun `When given Context returns a non null ApplicationContext, uses it`() {
         val sentryOptions = SentryAndroidOptions()
         val mockApp = mock<Application>()
         val mockContext = mock<Context>()
@@ -222,7 +222,7 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
-    fun `When given Context is not an Application class and ApplicationContext is null, keep given Context`() {
+    fun `When given Context returns a null ApplicationContext is null, keep given Context`() {
         val sentryOptions = SentryAndroidOptions()
         val mockContext = mock<Context>()
         whenever(mockContext.applicationContext).thenReturn(null)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -1,8 +1,10 @@
 package io.sentry.android.core
 
+import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.MainEventProcessor
 import io.sentry.core.SentryOptions
@@ -205,6 +207,26 @@ class AndroidOptionsInitializerTest {
         AndroidOptionsInitializer.init(sentryOptions, mockContext)
         val actual = sentryOptions.integrations.firstOrNull { it is EnvelopeFileObserverIntegration }
         assertNotNull(actual)
+    }
+
+    @Test
+    fun `When given Context is not an Application class, get and set ApplicationContext`() {
+        val sentryOptions = SentryAndroidOptions()
+        val mockApp = mock<Application>()
+        val mockContext = mock<Context>()
+        whenever(mockContext.applicationContext).thenReturn(mockApp)
+
+        AndroidOptionsInitializer.init(sentryOptions, mockContext)
+        assertNotNull(mockContext)
+    }
+
+    @Test
+    fun `When given Context is not an Application class and ApplicationContext is null, throw IllegalArgumentException`() {
+        val sentryOptions = SentryAndroidOptions()
+        val mockContext = mock<Context>()
+        whenever(mockContext.applicationContext).thenReturn(null)
+
+        assertFailsWith<IllegalArgumentException> { AndroidOptionsInitializer.init(sentryOptions, mockContext) }
     }
 
     private fun createMockContext(): Context {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegrationTest.kt
@@ -9,11 +9,14 @@ import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.Breadcrumb
 import io.sentry.core.IHub
 import io.sentry.core.SentryLevel
+import java.lang.NullPointerException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
@@ -39,6 +42,17 @@ class AppComponentsBreadcrumbsIntegrationTest {
     }
 
     @Test
+    fun `When app components breadcrumb is enabled, but ComponentCallbacks is not ready, do not throw`() {
+        val sut = fixture.getSut()
+        val options = SentryAndroidOptions()
+        val hub = mock<IHub>()
+        sut.register(hub, options)
+        whenever(fixture.context.registerComponentCallbacks(any())).thenThrow(NullPointerException())
+        sut.register(hub, options)
+        assertFalse(options.isEnableAppComponentBreadcrumbs)
+    }
+
+    @Test
     fun `When app components breadcrumb is disabled, it doesn't register callback`() {
         val sut = fixture.getSut()
         val options = SentryAndroidOptions().apply {
@@ -57,6 +71,17 @@ class AppComponentsBreadcrumbsIntegrationTest {
         sut.register(hub, options)
         sut.close()
         verify(fixture.context).unregisterComponentCallbacks(any())
+    }
+
+    @Test
+    fun `When app components breadcrumb is closed, but ComponentCallbacks is not ready, do not throw`() {
+        val sut = fixture.getSut()
+        val options = SentryAndroidOptions()
+        val hub = mock<IHub>()
+        whenever(fixture.context.registerComponentCallbacks(any())).thenThrow(NullPointerException())
+        whenever(fixture.context.unregisterComponentCallbacks(any())).thenThrow(NullPointerException())
+        sut.register(hub, options)
+        sut.close()
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: initing SDK on AttachBaseContext
Similar issue getsentry/sentry-java/pull/714


## :bulb: Motivation and Context
Fix #408


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
