### PR TITLE
fix: before raising ANR event, we check ProcessErrorStateInfo if available

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
@@ -92,7 +92,8 @@ final class ANRWatchDog extends Thread {
           continue;
         }
 
-        // we only raise an ANR if the process is in ANR state.
+        // we only raise an ANR event if the process is in ANR state.
+        // if ActivityManager is not available, we'll still be able to send ANRs
         final ActivityManager am =
             (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
@@ -27,7 +27,6 @@ final class ANRWatchDog extends Thread {
   private AtomicLong tick = new AtomicLong(0);
   private AtomicBoolean reported = new AtomicBoolean(false);
 
-  @SuppressWarnings("UnusedVariable")
   private final @NotNull Context context;
 
   @SuppressWarnings("UnnecessaryLambda")
@@ -100,7 +99,7 @@ final class ANRWatchDog extends Thread {
         if (am != null) {
           final List<ActivityManager.ProcessErrorStateInfo> processesInErrorState =
               am.getProcessesInErrorState();
-          // if list is null, there are no process in ANR state.
+          // if list is null, there's no process in ANR state.
           if (processesInErrorState == null) {
             continue;
           }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
@@ -2,9 +2,15 @@
 // Based on the class above. The API unnecessary here was removed.
 package io.sentry.android.core;
 
+import static android.app.ActivityManager.ProcessErrorStateInfo.NOT_RESPONDING;
+
+import android.app.ActivityManager;
+import android.content.Context;
 import android.os.Debug;
 import io.sentry.core.ILogger;
 import io.sentry.core.SentryLevel;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
@@ -19,21 +25,25 @@ final class ANRWatchDog extends Thread {
   private final long timeoutIntervalMillis;
   private final @NotNull ILogger logger;
   private AtomicLong tick = new AtomicLong(0);
-  private volatile boolean reported = false;
+  private AtomicBoolean reported = new AtomicBoolean(false);
+
+  @SuppressWarnings("UnusedVariable")
+  private final @NotNull Context context;
 
   @SuppressWarnings("UnnecessaryLambda")
   private final Runnable ticker =
       () -> {
         tick = new AtomicLong(0);
-        reported = false;
+        reported.set(false);
       };
 
   ANRWatchDog(
       long timeoutIntervalMillis,
       boolean reportInDebug,
       @NotNull ANRListener listener,
-      @NotNull ILogger logger) {
-    this(timeoutIntervalMillis, reportInDebug, listener, logger, new MainLooperHandler());
+      @NotNull ILogger logger,
+      final @NotNull Context context) {
+    this(timeoutIntervalMillis, reportInDebug, listener, logger, new MainLooperHandler(), context);
   }
 
   @TestOnly
@@ -42,16 +52,17 @@ final class ANRWatchDog extends Thread {
       boolean reportInDebug,
       @NotNull ANRListener listener,
       @NotNull ILogger logger,
-      @NotNull IHandler uiHandler) {
+      @NotNull IHandler uiHandler,
+      final @NotNull Context context) {
     super();
     this.reportInDebug = reportInDebug;
     this.anrListener = listener;
     this.timeoutIntervalMillis = timeoutIntervalMillis;
     this.logger = logger;
     this.uiHandler = uiHandler;
+    this.context = context;
   }
 
-  @SuppressWarnings("NonAtomicOperationOnVolatileField")
   @Override
   public void run() {
     setName("|ANR-WatchDog|");
@@ -73,14 +84,36 @@ final class ANRWatchDog extends Thread {
       }
 
       // If the main thread has not handled ticker, it is blocked. ANR.
-      if (tick.get() != 0 && !reported) {
-        //noinspection ConstantConditions
+      if (tick.get() != 0 && !reported.get()) {
         if (!reportInDebug && (Debug.isDebuggerConnected() || Debug.waitingForDebugger())) {
           logger.log(
               SentryLevel.DEBUG,
               "An ANR was detected but ignored because the debugger is connected.");
-          reported = true;
+          reported.set(true);
           continue;
+        }
+
+        // we only raise an ANR if the process is in ANR state.
+        final ActivityManager am =
+            (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+
+        if (am != null) {
+          final List<ActivityManager.ProcessErrorStateInfo> processesInErrorState =
+              am.getProcessesInErrorState();
+          // if list is null, there are no process in ANR state.
+          if (processesInErrorState == null) {
+            continue;
+          }
+          boolean isAnr = false;
+          for (ActivityManager.ProcessErrorStateInfo item : processesInErrorState) {
+            if (item.condition == NOT_RESPONDING) {
+              isAnr = true;
+              break;
+            }
+          }
+          if (!isAnr) {
+            continue;
+          }
         }
 
         logger.log(SentryLevel.INFO, "Raising ANR");
@@ -91,7 +124,8 @@ final class ANRWatchDog extends Thread {
             new ApplicationNotResponding(message, uiHandler.getThread());
         anrListener.onAppNotResponding(error);
         interval = timeoutIntervalMillis;
-        reported = true;
+
+        reported.set(true);
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -114,7 +114,7 @@ final class AndroidOptionsInitializer {
               }
             }));
 
-    options.addIntegration(new AnrIntegration());
+    options.addIntegration(new AnrIntegration(context));
     options.addIntegration(new AppLifecycleIntegration());
 
     // registerActivityLifecycleCallbacks is only available if Context is an AppContext

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -1,5 +1,6 @@
 package io.sentry.android.core;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import io.sentry.core.IHub;
 import io.sentry.core.ILogger;
@@ -31,6 +32,7 @@ public final class AnrIntegration implements Integration, Closeable {
    * Responsible for watching UI thread. being static to avoid multiple instances running at the
    * same time.
    */
+  @SuppressLint("StaticFieldLeak") // we have watchDogLock to avoid those leaks
   private static @Nullable ANRWatchDog anrWatchDog;
 
   private @Nullable SentryOptions options;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -1,5 +1,6 @@
 package io.sentry.android.core;
 
+import android.content.Context;
 import io.sentry.core.IHub;
 import io.sentry.core.ILogger;
 import io.sentry.core.Integration;
@@ -19,6 +20,12 @@ import org.jetbrains.annotations.TestOnly;
  * (ANR) error is triggered. Sends an event if an ANR happens
  */
 public final class AnrIntegration implements Integration, Closeable {
+
+  private final @NotNull Context context;
+
+  public AnrIntegration(final @NotNull Context context) {
+    this.context = context;
+  }
 
   /**
    * Responsible for watching UI thread. being static to avoid multiple instances running at the
@@ -56,7 +63,8 @@ public final class AnrIntegration implements Integration, Closeable {
                   options.getAnrTimeoutIntervalMillis(),
                   options.isAnrReportInDebug(),
                   error -> reportANR(hub, options.getLogger(), error),
-                  options.getLogger());
+                  options.getLogger(),
+                  context);
           anrWatchDog.start();
 
           options.getLogger().log(SentryLevel.DEBUG, "AnrIntegration installed.");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ANRWatchDogTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ANRWatchDogTest.kt
@@ -1,6 +1,11 @@
 package io.sentry.android.core
 
+import android.app.ActivityManager
+import android.app.ActivityManager.ProcessErrorStateInfo.NOT_RESPONDING
+import android.app.ActivityManager.ProcessErrorStateInfo.NO_ERROR
+import android.content.Context
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.core.ANRWatchDog.ANRListener
@@ -70,6 +75,85 @@ class ANRWatchDogTest {
             } while (!invoked && waitCount++ < 100)
 
             assertTrue(invoked)
+            assertNull(anr) // callback never ran
+        } finally {
+            sut.interrupt()
+            es.shutdown()
+        }
+    }
+
+    @Test
+    fun `when ANR is detected and ActivityManager has ANR process, callback not invoked`() {
+        var anr: ApplicationNotResponding? = null
+        val handler = mock<IHandler>()
+        val thread = mock<Thread>()
+        val expectedState = Thread.State.BLOCKED
+        val stacktrace = StackTraceElement("class", "method", "fileName", 10)
+        whenever(thread.state).thenReturn(expectedState)
+        whenever(thread.stackTrace).thenReturn(arrayOf(stacktrace))
+        val latch = CountDownLatch(1)
+        whenever(handler.post(any())).then { latch.countDown() }
+        whenever(handler.thread).thenReturn(thread)
+        val interval = 1L
+        val context = mock<Context>()
+        val am = mock<ActivityManager>()
+
+        whenever(context.getSystemService(eq(Context.ACTIVITY_SERVICE))).thenReturn(am)
+        val stateInfo = ActivityManager.ProcessErrorStateInfo()
+        stateInfo.condition = NOT_RESPONDING
+        val anrs = listOf(stateInfo)
+        whenever(am.processesInErrorState).thenReturn(anrs)
+        val sut = ANRWatchDog(interval, true, ANRListener { a -> anr = a }, mock(), handler, context)
+        val es = Executors.newSingleThreadExecutor()
+        try {
+            es.submit { sut.run() }
+
+            assertTrue(latch.await(10L, TimeUnit.SECONDS)) // Wait until worker posts the job for the "UI thread"
+            var waitCount = 0
+            do {
+                Thread.sleep(100) // Let worker realize this is ANR
+            } while (anr == null && waitCount++ < 100)
+
+            assertNotNull(anr)
+            assertEquals(expectedState, anr!!.thread.state)
+            assertEquals(stacktrace.className, anr!!.stackTrace[0].className)
+        } finally {
+            sut.interrupt()
+            es.shutdown()
+        }
+    }
+
+    @Test
+    fun `when ANR is detected and ActivityManager has not ANR process, callback is not invoked`() {
+        var anr: ApplicationNotResponding? = null
+        val handler = mock<IHandler>()
+        val thread = mock<Thread>()
+        val expectedState = Thread.State.BLOCKED
+        val stacktrace = StackTraceElement("class", "method", "fileName", 10)
+        whenever(thread.state).thenReturn(expectedState)
+        whenever(thread.stackTrace).thenReturn(arrayOf(stacktrace))
+        val latch = CountDownLatch(1)
+        whenever(handler.post(any())).then { latch.countDown() }
+        whenever(handler.thread).thenReturn(thread)
+        val interval = 1L
+        val context = mock<Context>()
+        val am = mock<ActivityManager>()
+
+        whenever(context.getSystemService(eq(Context.ACTIVITY_SERVICE))).thenReturn(am)
+        val stateInfo = ActivityManager.ProcessErrorStateInfo()
+        stateInfo.condition = NO_ERROR
+        val anrs = listOf(stateInfo)
+        whenever(am.processesInErrorState).thenReturn(anrs)
+        val sut = ANRWatchDog(interval, true, ANRListener { a -> anr = a }, mock(), handler, context)
+        val es = Executors.newSingleThreadExecutor()
+        try {
+            es.submit { sut.run() }
+
+            assertTrue(latch.await(10L, TimeUnit.SECONDS)) // Wait until worker posts the job for the "UI thread"
+            var waitCount = 0
+            do {
+                Thread.sleep(100) // Let worker realize this is ANR
+            } while (anr == null && waitCount++ < 100)
             assertNull(anr) // callback never ran
         } finally {
             sut.interrupt()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ANRWatchDogTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ANRWatchDogTest.kt
@@ -27,7 +27,7 @@ class ANRWatchDogTest {
         whenever(handler.post(any())).then { latch.countDown() }
         whenever(handler.thread).thenReturn(thread)
         val interval = 1L
-        val sut = ANRWatchDog(interval, true, ANRListener { a -> anr = a }, mock(), handler)
+        val sut = ANRWatchDog(interval, true, ANRListener { a -> anr = a }, mock(), handler, mock())
         val es = Executors.newSingleThreadExecutor()
         try {
             es.submit { sut.run() }
@@ -59,7 +59,7 @@ class ANRWatchDogTest {
         }
         whenever(handler.thread).thenReturn(thread)
         val interval = 1L
-        val sut = ANRWatchDog(interval, true, ANRListener { a -> anr = a }, mock(), handler)
+        val sut = ANRWatchDog(interval, true, ANRListener { a -> anr = a }, mock(), handler, mock())
         val es = Executors.newSingleThreadExecutor()
         try {
             es.submit { sut.run() }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ANRWatchDogTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ANRWatchDogTest.kt
@@ -83,7 +83,7 @@ class ANRWatchDogTest {
     }
 
     @Test
-    fun `when ANR is detected and ActivityManager has ANR process, callback not invoked`() {
+    fun `when ANR is detected and ActivityManager has ANR process, callback is invoked`() {
         var anr: ApplicationNotResponding? = null
         val handler = mock<IHandler>()
         val thread = mock<Thread>()
@@ -124,7 +124,7 @@ class ANRWatchDogTest {
     }
 
     @Test
-    fun `when ANR is detected and ActivityManager has not ANR process, callback is not invoked`() {
+    fun `when ANR is detected and ActivityManager has no ANR process, callback is not invoked`() {
         var anr: ApplicationNotResponding? = null
         val handler = mock<IHandler>()
         val thread = mock<Thread>()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 
 class AnrIntegrationTest {
 
-    private val integration = AnrIntegration()
+    private val integration = AnrIntegration(mock())
 
     @BeforeTest
     fun `before each test`() {
@@ -34,7 +34,7 @@ class AnrIntegrationTest {
         val options = SentryAndroidOptions()
         options.isAnrEnabled = false
         val hub = mock<IHub>()
-        val integration = AnrIntegration()
+        val integration = AnrIntegration(mock())
         integration.register(hub, options)
         assertNull(integration.anrWatchDog)
     }
@@ -42,7 +42,7 @@ class AnrIntegrationTest {
     @Test
     fun `When ANR watch dog is triggered, it should capture exception`() {
         val hub = mock<IHub>()
-        val integration = AnrIntegration()
+        val integration = AnrIntegration(mock())
         integration.reportANR(hub, mock(), mock())
         verify(hub).captureException(any())
     }
@@ -51,7 +51,7 @@ class AnrIntegrationTest {
     fun `When ANR integration is closed, watch dog should stop`() {
         val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        val integration = AnrIntegration()
+        val integration = AnrIntegration(mock())
         integration.register(hub, options)
         assertNotNull(integration.anrWatchDog)
         integration.close()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: before raising ANR event, we check ProcessErrorStateInfo if available


## :bulb: Motivation and Context
ANR events are too noisy
#406


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
