### PR TITLE
fix: Phone state breadcrumbs require read_phone_state on older OS versions

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
@@ -1,5 +1,6 @@
 package io.sentry.android.core;
 
+import static android.Manifest.permission.READ_PHONE_STATE;
 import static android.telephony.PhoneStateListener.LISTEN_CALL_STATE;
 import static android.telephony.PhoneStateListener.LISTEN_NONE;
 
@@ -7,6 +8,7 @@ import android.content.Context;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
 import androidx.annotation.Nullable;
+import io.sentry.android.core.util.Permissions;
 import io.sentry.core.Breadcrumb;
 import io.sentry.core.IHub;
 import io.sentry.core.Integration;
@@ -44,7 +46,8 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
             "enableSystemEventBreadcrumbs enabled: %s",
             this.options.isEnableSystemEventBreadcrumbs());
 
-    if (this.options.isEnableSystemEventBreadcrumbs()) {
+    if (this.options.isEnableSystemEventBreadcrumbs()
+        && Permissions.hasPermission(context, READ_PHONE_STATE)) {
       telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
       if (telephonyManager != null) {
         try {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
@@ -55,10 +55,10 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
           telephonyManager.listen(listener, LISTEN_CALL_STATE);
 
           options.getLogger().log(SentryLevel.DEBUG, "PhoneStateBreadcrumbsIntegration installed.");
-        } catch (NullPointerException e) {
+        } catch (Exception e) {
           this.options
               .getLogger()
-              .log(SentryLevel.INFO, e, "TelephonyManager is not ready for use.");
+              .log(SentryLevel.INFO, e, "TelephonyManager is not available or ready to use.");
         }
       } else {
         this.options.getLogger().log(SentryLevel.INFO, "TelephonyManager is not available");


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: Phone state breadcrumbs require read_phone_state on older OS versions


## :bulb: Motivation and Context
Fix: #413


## :green_heart: How did you test it?
running API 14 and 16

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
