### PR TITLE
fix: make NoOpLogger public

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/NoOpLogger.java
+++ b/sentry-core/src/main/java/io/sentry/core/NoOpLogger.java
@@ -1,7 +1,7 @@
 package io.sentry.core;
 
 /** No-op implementation of ILogger */
-final class NoOpLogger implements ILogger {
+public final class NoOpLogger implements ILogger {
 
   private static final NoOpLogger instance = new NoOpLogger();
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
make NoOpLogger public


## :bulb: Motivation and Context
```
SentryAndroid.init(applicationContext) { options ->
  options.setLogger(null)
}
```
Still logs a few thing that runs before the OptionsConfiguration.configure.

one may need to `SentryAndroid.init(context, NoOpLogger.getInstance())` if they want a total radio silence.

The other way would be to implement `ILogger` on its own that does nothing aka NoOp.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
