### PR TITLE
fix: Sentry.init register integrations after creating main Hub instead of in the main Hub ctor

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.sentry.core.Hub
-import io.sentry.core.HubAdapter
+// import io.sentry.core.HubAdapter
 import io.sentry.core.SentryOptions
 import java.io.File
 import java.nio.file.Files
@@ -46,9 +46,9 @@ class EnvelopeFileObserverIntegrationTest {
         options.cacheDirPath = file.absolutePath
         options.addIntegration(integrationMock)
         options.setSerializer(mock())
-        val expected = HubAdapter.getInstance()
+//        val expected = HubAdapter.getInstance()
         val hub = Hub(options)
-        verify(integrationMock).register(expected, options)
+//        verify(integrationMock).register(expected, options)
         hub.close()
         verify(integrationMock).close()
     }

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -34,9 +34,9 @@ public final class Hub implements IHub {
     this(options, createRootStackItem(options));
 
     // Register integrations against a root Hub
-    for (Integration integration : options.getIntegrations()) {
-      integration.register(HubAdapter.getInstance(), options);
-    }
+    //    for (Integration integration : options.getIntegrations()) {
+    //      integration.register(HubAdapter.getInstance(), options);
+    //    }
   }
 
   private Hub(final @NotNull SentryOptions options, final @Nullable StackItem rootStackItem) {

--- a/sentry-core/src/main/java/io/sentry/core/Hub.java
+++ b/sentry-core/src/main/java/io/sentry/core/Hub.java
@@ -33,10 +33,7 @@ public final class Hub implements IHub {
   public Hub(final @NotNull SentryOptions options) {
     this(options, createRootStackItem(options));
 
-    // Register integrations against a root Hub
-    //    for (Integration integration : options.getIntegrations()) {
-    //      integration.register(HubAdapter.getInstance(), options);
-    //    }
+    // Integrations are no longer registed on Hub ctor, but on Sentry.init
   }
 
   private Hub(final @NotNull SentryOptions options, final @Nullable StackItem rootStackItem) {

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -142,7 +142,16 @@ public final class Sentry {
 
     IHub hub = getCurrentHub();
     mainHub = new Hub(options);
+
     currentHub.set(mainHub);
+
+    // when integrations are registered on Hub e integrations are fired,
+    // it might and actually happened that integrations called captureSomething
+    // and hub was still NoOp.
+    for (Integration integration : options.getIntegrations()) {
+      integration.register(HubAdapter.getInstance(), options);
+    }
+
     hub.close();
   }
 

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -151,7 +151,7 @@ public final class Sentry {
     // it might and actually happened that integrations called captureSomething
     // and hub was still NoOp.
     // Registering integrations here make sure that Hub is already created.
-    for (Integration integration : options.getIntegrations()) {
+    for (final Integration integration : options.getIntegrations()) {
       integration.register(HubAdapter.getInstance(), options);
     }
   }

--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -145,14 +145,15 @@ public final class Sentry {
 
     currentHub.set(mainHub);
 
-    // when integrations are registered on Hub e integrations are fired,
+    hub.close();
+
+    // when integrations are registered on Hub ctor and async integrations are fired,
     // it might and actually happened that integrations called captureSomething
     // and hub was still NoOp.
+    // Registering integrations here make sure that Hub is already created.
     for (Integration integration : options.getIntegrations()) {
       integration.register(HubAdapter.getInstance(), options);
     }
-
-    hub.close();
   }
 
   /** Close the SDK */

--- a/sentry-core/src/test/java/io/sentry/core/HubTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/HubTest.kt
@@ -22,6 +22,7 @@ import java.util.Queue
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -49,6 +50,7 @@ class HubTest {
         assertEquals("Hub requires a DSN to be instantiated. Considering using the NoOpHub is no DSN is available.", ex.message)
     }
 
+    @Ignore("Sentry static class is registering integrations")
     @Test
     fun `when a root hub is initialized, integrations are registered`() {
         val integrationMock = mock<Integration>()
@@ -70,9 +72,9 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         options.addIntegration(integrationMock)
-        val expected = HubAdapter.getInstance()
+//        val expected = HubAdapter.getInstance()
         val hub = Hub(options)
-        verify(integrationMock).register(expected, options)
+//        verify(integrationMock).register(expected, options)
         hub.clone()
         verifyNoMoreInteractions(integrationMock)
     }

--- a/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/UncaughtExceptionHandlerIntegrationTest.kt
@@ -95,9 +95,9 @@ class UncaughtExceptionHandlerIntegrationTest {
         options.addIntegration(integrationMock)
         options.cacheDirPath = file.absolutePath
         options.setSerializer(mock())
-        val expected = HubAdapter.getInstance()
+//        val expected = HubAdapter.getInstance()
         val hub = Hub(options)
-        verify(integrationMock).register(expected, options)
+//        verify(integrationMock).register(expected, options)
         hub.close()
         verify(integrationMock).close()
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: Sentry.init register integrations after creating main Hub instead of in the main Hub ctor


## :bulb: Motivation and Context
when integrations are registered on Hub ctor and async integrations are fired,
it might and actually happened that integrations called captureSomething
and hub was still NoOp.
Registering integrations here make sure that Hub is already created.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
Find a proper way of registering global and only once integrations.