### PR TITLE
fix: filter trim memory breadcrumbs

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -107,13 +107,27 @@ public final class AppComponentsBreadcrumbsIntegration
   private void createLowMemoryBreadcrumb(final @Nullable Integer level) {
     if (hub != null) {
       final Breadcrumb breadcrumb = new Breadcrumb();
+      if (level != null) {
+        // only add breadcrumb if TRIM_MEMORY_BACKGROUND, TRIM_MEMORY_MODERATE or
+        // TRIM_MEMORY_COMPLETE.
+        // Release as much memory as the process can.
+
+        // TRIM_MEMORY_UI_HIDDEN, TRIM_MEMORY_RUNNING_MODERATE, TRIM_MEMORY_RUNNING_LOW and
+        // TRIM_MEMORY_RUNNING_CRITICAL.
+        // Release any memory that your app doesn't need to run.
+        // So they are still not so critical at the point of killing the process.
+        // https://developer.android.com/topic/performance/memory
+
+        if (level < TRIM_MEMORY_BACKGROUND) {
+          return;
+        }
+        breadcrumb.setData("level", level);
+      }
+
       breadcrumb.setType("system");
       breadcrumb.setCategory("device.event");
       breadcrumb.setMessage("Low memory");
       breadcrumb.setData("action", "LOW_MEMORY");
-      if (level != null) {
-        breadcrumb.setData("level", level);
-      }
       breadcrumb.setLevel(SentryLevel.WARNING);
       hub.addBreadcrumb(breadcrumb);
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegrationTest.kt
@@ -104,12 +104,22 @@ class AppComponentsBreadcrumbsIntegrationTest {
         val options = SentryAndroidOptions()
         val hub = mock<IHub>()
         sut.register(hub, options)
-        sut.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW)
+        sut.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
         verify(hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals("device.event", it.category)
             assertEquals("system", it.type)
             assertEquals(SentryLevel.WARNING, it.level)
         })
+    }
+
+    @Test
+    fun `When trim memory event with level not so high, do not add a breadcrumb`() {
+        val sut = fixture.getSut()
+        val options = SentryAndroidOptions()
+        val hub = mock<IHub>()
+        sut.register(hub, options)
+        sut.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL)
+        verify(hub, never()).addBreadcrumb(any<Breadcrumb>())
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: filter trim memory breadcrumbs


## :bulb: Motivation and Context
no need to add breadcrumbs for memory warnings that are not so important, yet.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
