### PR TITLE
modified sample to reproduce #379

### DIFF
--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
     <!--    <meta-data android:name="io.sentry.anr.report-debug" android:value="true" />-->
 
     <!--    how to disable ANR-->
-    <!--    <meta-data android:name="io.sentry.anr.enable" android:value="false" />-->
+        <meta-data android:name="io.sentry.anr.enable" android:value="false" />
 
     <!--    how to disable the auto-init-->
     <!--    <meta-data android:name="io.sentry.auto-init" android:value="false" />-->

--- a/sentry-sample/src/main/cpp/native-sample.cpp
+++ b/sentry-sample/src/main/cpp/native-sample.cpp
@@ -14,10 +14,24 @@ JNIEXPORT void JNICALL Java_io_sentry_sample_NativeSample_crash(JNIEnv *env, jcl
 
 JNIEXPORT void JNICALL Java_io_sentry_sample_NativeSample_message(JNIEnv *env, jclass cls) {
     __android_log_print(ANDROID_LOG_WARN, TAG, "Sending message.");
+
+    jclass clazz = env->FindClass("io/sentry/sample/NativeSample");
+    jmethodID method = env->GetStaticMethodID(clazz, "test",
+                                              "()Ljava/lang/String;");
+    jstring result = (jstring) env->CallStaticObjectMethod(clazz, method);
+    // if I do a NPE check, it bails out and it works
+//    if (result == NULL) {
+//        return;
+//    }
+
+// lets keep running to segfault as result is NULL
+
+    const char *nativeString = env->GetStringUTFChars(result, 0);
+
     sentry_value_t event = sentry_value_new_message_event(
             /*   level */ SENTRY_LEVEL_INFO,
             /*  logger */ "custom",
-            /* message */ "It works!"
+            /* message */ nativeString
     );
     sentry_capture_event(event);
 }

--- a/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
+++ b/sentry-sample/src/main/java/io/sentry/sample/NativeSample.java
@@ -1,5 +1,10 @@
 package io.sentry.sample;
 
+import android.annotation.SuppressLint;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class NativeSample {
   public static native void crash();
 
@@ -7,5 +12,19 @@ public class NativeSample {
 
   static {
     System.loadLibrary("native-sample");
+  }
+
+
+  @SuppressLint("NewApi")
+  public static String test() {
+    Map<String, String> maps = new HashMap<>();
+    maps.put("test", "test");
+
+    // RequiresApi API 24, so run on <= 23 (max Android 6) to simulate a NoClassDefFoundError, which is caught by UncaughtExceptionHandlerIntegration.uncaughtException
+    maps.forEach((s, s2) -> {
+      System.out.println("s = " + s + " s2 " + s2);
+    });
+
+    return "test"; // (jstring result) will be null anyway as forEach throws NoClassDefFoundError
   }
 }


### PR DESCRIPTION
just a draft to reproduce #379

paste bin
https://pastebin.com/fy5LmJgv

findings:
when there are an uncaught exception and a segfault at the same time as this example does, the
UncaughtExceptionHandlerIntegration.uncaughtException and the segfault handler try to execute its handlers, but one interferes in the other.

eg UncaughtExceptionHandlerIntegration.uncaughtException probably sends a SIGABRT to the native layer and vice-versa, so sometimes none of them are able to finish its job.

If you add a breakpoint in one of them, the other handler is able to do its job and generate a crash event.
