### PR TITLE
fix: do not lookup sentry-debug-meta but instead load it directly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,8 @@ org.gradle.caching=true
 android.useAndroidX=true
 
 # Release information
-buildVersionCode=20029
-versionName=2.1.4
+buildVersionCode=20030
+versionName=2.1.5-SNAPSHOT
 
 # disable renderscript, it's enabled by default
 android.defaults.buildfeatures.renderscript=false

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -24,6 +24,7 @@ import io.sentry.android.core.util.DeviceOrientations;
 import io.sentry.android.core.util.RootChecker;
 import io.sentry.core.DateUtils;
 import io.sentry.core.EventProcessor;
+import io.sentry.core.ILogger;
 import io.sentry.core.SentryEvent;
 import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
@@ -80,6 +81,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private final @NotNull IBuildInfoProvider buildInfoProvider;
   private final @NotNull RootChecker rootChecker;
 
+  private final @NotNull ILogger logger;
+
   public DefaultAndroidEventProcessor(
       final @NotNull Context context,
       final @NotNull SentryOptions options,
@@ -98,6 +101,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       final @NotNull RootChecker rootChecker) {
     this.context = Objects.requireNonNull(context, "The application context is required.");
     this.options = Objects.requireNonNull(options, "The SentryOptions is required.");
+    this.logger = Objects.requireNonNull(options.getLogger(), "The Logger is required.");
     this.buildInfoProvider =
         Objects.requireNonNull(buildInfoProvider, "The BuildInfoProvider is required.");
     this.rootChecker = Objects.requireNonNull(rootChecker, "The RootChecker is required.");
@@ -111,9 +115,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   private @NotNull Map<String, Object> loadContextData() {
     Map<String, Object> map = new HashMap<>();
-    String[] proGuardUuids = getProGuardUuids();
-    if (proGuardUuids != null) {
-      map.put(PROGUARD_UUID, proGuardUuids);
+    String[] proguardUUIDs = getProguardUUIDs();
+    if (proguardUUIDs != null) {
+      map.put(PROGUARD_UUID, proguardUUIDs);
     }
 
     map.put(ROOTED, rootChecker.isDeviceRooted());
@@ -140,12 +144,10 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     if (ApplyScopeUtils.shouldApplyScopeData(hint)) {
       processNonCachedEvent(event);
     } else {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Event was cached so not applying data relevant to the current app execution/version: %s",
-              event.getEventId());
+      logger.log(
+          SentryLevel.DEBUG,
+          "Event was cached so not applying data relevant to the current app execution/version: %s",
+          event.getEventId());
     }
 
     if (event.getContexts().getDevice() == null) {
@@ -177,7 +179,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       event.setSdk(getSdkVersion());
     }
 
-    PackageInfo packageInfo = ContextUtils.getPackageInfo(context, options.getLogger());
+    PackageInfo packageInfo = ContextUtils.getPackageInfo(context, logger);
     if (packageInfo != null) {
       String versionCode = ContextUtils.getVersionCode(packageInfo);
 
@@ -197,24 +199,24 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private @Nullable List<DebugImage> getDebugImages() {
-    String[] uuids = null;
+    String[] proguardUUIDs = null;
     try {
-      Object proGuardUuids = contextData.get().get(PROGUARD_UUID);
-      if (proGuardUuids != null) {
-        uuids = (String[]) proGuardUuids;
+      Object proguardUUIDsObject = contextData.get().get(PROGUARD_UUID);
+      if (proguardUUIDsObject != null) {
+        proguardUUIDs = (String[]) proguardUUIDsObject;
       }
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting proGuardUuids.", e);
+      logger.log(SentryLevel.ERROR, "Error getting Proguard UUIDs.", e);
       return null;
     }
 
-    if (uuids == null || uuids.length == 0) {
+    if (proguardUUIDs == null || proguardUUIDs.length == 0) {
       return null;
     }
 
     List<DebugImage> images = new ArrayList<>();
 
-    for (String item : uuids) {
+    for (String item : proguardUUIDs) {
       DebugImage debugImage = new DebugImage();
       debugImage.setType("proguard");
       debugImage.setUuid(item);
@@ -310,7 +312,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       device.setBatteryTemperature(getBatteryTemperature(batteryIntent));
     }
     Boolean connected;
-    switch (ConnectivityChecker.getConnectionStatus(context, options.getLogger())) {
+    switch (ConnectivityChecker.getConnectionStatus(context, logger)) {
       case NOT_CONNECTED:
         connected = false;
         break;
@@ -329,7 +331,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         device.setSimulator((Boolean) emulator);
       }
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting emulator.", e);
+      logger.log(SentryLevel.ERROR, "Error getting emulator.", e);
     }
 
     ActivityManager.MemoryInfo memInfo = getMemInfo();
@@ -378,7 +380,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     if (device.getConnectionType() == null) {
       // wifi, ethernet or cellular, null if none
       device.setConnectionType(
-          ConnectivityChecker.getConnectionType(context, options.getLogger(), buildInfoProvider));
+          ConnectivityChecker.getConnectionType(context, logger, buildInfoProvider));
     }
 
     return device;
@@ -435,10 +437,10 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         actManager.getMemoryInfo(memInfo);
         return memInfo;
       }
-      options.getLogger().log(SentryLevel.INFO, "Error getting MemoryInfo.");
+      logger.log(SentryLevel.INFO, "Error getting MemoryInfo.");
       return null;
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting MemoryInfo.", e);
+      logger.log(SentryLevel.ERROR, "Error getting MemoryInfo.", e);
       return null;
     }
   }
@@ -457,7 +459,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try {
       return Build.MODEL.split(" ", -1)[0];
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting device family.", e);
+      logger.log(SentryLevel.ERROR, "Error getting device family.", e);
       return null;
     }
   }
@@ -480,7 +482,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
       return ((float) level / (float) scale) * percentMultiplier;
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting device battery level.", e);
+      logger.log(SentryLevel.ERROR, "Error getting device battery level.", e);
       return null;
     }
   }
@@ -496,7 +498,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       return plugged == BatteryManager.BATTERY_PLUGGED_AC
           || plugged == BatteryManager.BATTERY_PLUGGED_USB;
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting device charging state.", e);
+      logger.log(SentryLevel.ERROR, "Error getting device charging state.", e);
       return null;
     }
   }
@@ -508,7 +510,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         return ((float) temperature) / 10; // celsius
       }
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting battery temperature.", e);
+      logger.log(SentryLevel.ERROR, "Error getting battery temperature.", e);
     }
     return null;
   }
@@ -525,15 +527,13 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       deviceOrientation =
           DeviceOrientations.getOrientation(context.getResources().getConfiguration().orientation);
       if (deviceOrientation == null) {
-        options
-            .getLogger()
-            .log(
-                SentryLevel.INFO,
-                "No device orientation available (ORIENTATION_SQUARE|ORIENTATION_UNDEFINED)");
+        logger.log(
+            SentryLevel.INFO,
+            "No device orientation available (ORIENTATION_SQUARE|ORIENTATION_UNDEFINED)");
         return null;
       }
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting device orientation.", e);
+      logger.log(SentryLevel.ERROR, "Error getting device orientation.", e);
     }
     return deviceOrientation;
   }
@@ -563,12 +563,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
           || Build.PRODUCT.contains("emulator")
           || Build.PRODUCT.contains("simulator");
     } catch (Exception e) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.ERROR,
-              "Error checking whether application is running in an emulator.",
-              e);
+      logger.log(
+          SentryLevel.ERROR, "Error checking whether application is running in an emulator.", e);
       return null;
     }
   }
@@ -584,7 +580,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long totalBlocks = getBlockCountLong(stat);
       return totalBlocks * blockSize;
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting total internal storage amount.", e);
+      logger.log(SentryLevel.ERROR, "Error getting total internal storage amount.", e);
       return null;
     }
   }
@@ -639,9 +635,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long availableBlocks = getAvailableBlocksLong(stat);
       return availableBlocks * blockSize;
     } catch (Exception e) {
-      options
-          .getLogger()
-          .log(SentryLevel.ERROR, "Error getting unused internal storage amount.", e);
+      logger.log(SentryLevel.ERROR, "Error getting unused internal storage amount.", e);
       return null;
     }
   }
@@ -652,10 +646,10 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       if (path != null) { // && path.canRead()) { canRead() will read return false
         return new StatFs(path.getPath());
       }
-      options.getLogger().log(SentryLevel.INFO, "Not possible to read external files directory");
+      logger.log(SentryLevel.INFO, "Not possible to read external files directory");
       return null;
     }
-    options.getLogger().log(SentryLevel.INFO, "External storage is not mounted or emulated.");
+    logger.log(SentryLevel.INFO, "External storage is not mounted or emulated.");
     return null;
   }
 
@@ -696,7 +690,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         return file;
       }
     } else {
-      options.getLogger().log(SentryLevel.INFO, "Not possible to read getExternalFilesDirs");
+      logger.log(SentryLevel.INFO, "Not possible to read getExternalFilesDirs");
     }
     return null;
   }
@@ -713,7 +707,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long totalBlocks = getBlockCountLong(stat);
       return totalBlocks * blockSize;
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting total external storage amount.", e);
+      logger.log(SentryLevel.ERROR, "Error getting total external storage amount.", e);
       return null;
     }
   }
@@ -737,9 +731,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long availableBlocks = getAvailableBlocksLong(stat);
       return availableBlocks * blockSize;
     } catch (Exception e) {
-      options
-          .getLogger()
-          .log(SentryLevel.ERROR, "Error getting unused external storage amount.", e);
+      logger.log(SentryLevel.ERROR, "Error getting unused external storage amount.", e);
       return null;
     }
   }
@@ -753,7 +745,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try {
       return context.getResources().getDisplayMetrics();
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting DisplayMetrics.", e);
+      logger.log(SentryLevel.ERROR, "Error getting DisplayMetrics.", e);
       return null;
     }
   }
@@ -775,7 +767,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         os.setRooted((Boolean) rooted);
       }
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting OperatingSystem.", e);
+      logger.log(SentryLevel.ERROR, "Error getting OperatingSystem.", e);
     }
 
     return os;
@@ -807,7 +799,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try (BufferedReader br = new BufferedReader(new FileReader(file))) {
       return br.readLine();
     } catch (IOException e) {
-      options.getLogger().log(SentryLevel.ERROR, errorMsg, e);
+      logger.log(SentryLevel.ERROR, errorMsg, e);
     }
 
     return defaultVersion;
@@ -831,7 +823,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         return context.getString(stringId);
       }
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting application name.", e);
+      logger.log(SentryLevel.ERROR, "Error getting application name.", e);
     }
 
     return null;
@@ -852,7 +844,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         return (String) androidId;
       }
     } catch (Exception e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting androidId.", e);
+      logger.log(SentryLevel.ERROR, "Error getting androidId.", e);
     }
     return null;
   }
@@ -871,7 +863,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       try {
         androidId = Installation.id(context);
       } catch (RuntimeException e) {
-        options.getLogger().log(SentryLevel.ERROR, "Could not generate device Id.", e);
+        logger.log(SentryLevel.ERROR, "Could not generate device Id.", e);
 
         return null;
       }
@@ -880,36 +872,31 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     return androidId;
   }
 
-  private @Nullable String[] getProGuardUuids() {
-    final AssetManager assets = context.getAssets();
-
-    try (final InputStream is =
-        new BufferedInputStream(assets.open("sentry-debug-meta.properties"))) {
+  private @Nullable String[] getProguardUUIDs() {
+    try (final AssetManager assets = context.getAssets();
+        final InputStream is =
+            new BufferedInputStream(assets.open("sentry-debug-meta.properties"))) {
       final Properties properties = new Properties();
       properties.load(is);
 
       final String uuid = properties.getProperty("io.sentry.ProguardUuids");
       if (uuid != null && !uuid.isEmpty()) {
-        final String[] proguardUuids = uuid.split("\\|", -1);
+        final String[] proguardUUIDs = uuid.split("\\|", -1);
 
         // it should be only 1 proguard uuid, but the API accepts an Array so keeping it consistency
-        for (final String item : proguardUuids) {
-          options.getLogger().log(SentryLevel.DEBUG, "ProguardUuids found: %s", item);
+        for (final String item : proguardUUIDs) {
+          logger.log(SentryLevel.DEBUG, "Proguard UUID found: %s", item);
         }
-        return proguardUuids;
+        return proguardUUIDs;
       }
-      options
-          .getLogger()
-          .log(
-              SentryLevel.INFO, "io.sentry.ProguardUuids property was not found or it is invalid.");
+      logger.log(
+          SentryLevel.INFO, "io.sentry.ProguardUuids property was not found or it is invalid.");
     } catch (FileNotFoundException e) {
-      options.getLogger().log(SentryLevel.INFO, "sentry-debug-meta.properties file was not found.");
+      logger.log(SentryLevel.INFO, "sentry-debug-meta.properties file was not found.");
     } catch (IOException e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error getting Proguard UUIDs.", e);
+      logger.log(SentryLevel.ERROR, "Error getting Proguard UUIDs.", e);
     } catch (RuntimeException e) {
-      options
-          .getLogger()
-          .log(SentryLevel.ERROR, "sentry-debug-meta.properties file is malformed.", e);
+      logger.log(SentryLevel.ERROR, "sentry-debug-meta.properties file is malformed.", e);
     }
 
     return null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -890,8 +890,12 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
       final String uuid = properties.getProperty("io.sentry.ProguardUuids");
       if (uuid != null && !uuid.isEmpty()) {
-        String[] proguardUuids = uuid.split("\\|", -1);
-        options.getLogger().log(SentryLevel.DEBUG, "ProguardUuids found: %s", proguardUuids);
+        final String[] proguardUuids = uuid.split("\\|", -1);
+
+        // it should be only 1 proguard uuid, but the API accepts an Array so keeping it consistency
+        for (final String item : proguardUuids) {
+          options.getLogger().log(SentryLevel.DEBUG, "ProguardUuids found: %s", item);
+        }
         return proguardUuids;
       }
       options


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: do not lookup sentry-debug-meta but instead loads it directly


## :bulb: Motivation and Context
probably fixes #442
one may have thousands of asset files and this will slow down the startup time.
instead of looking up if the sentry-debug-meta exists, we try to load it directly and take care of `FileNotFoundException`.
the downside is: if one doesn't have asset files, catching the exception might be more expensive than the looking up itself, but worth it.

## :green_heart: How did you test it?
running it, tests are in place.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
ideally `sentry-debug-meta.properties` will be a manifest config or SentryOptions, as a file this is suboptimal, but needed because of retro compatibility.