### PR TITLE
add READ_PHONE_STATE permission on the sample app.

### DIFF
--- a/sentry-sample/src/main/AndroidManifest.xml
+++ b/sentry-sample/src/main/AndroidManifest.xml
@@ -6,6 +6,10 @@
   <!--  extra recommended permission, we'd be able to check network status-->
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+  <!-- add extra permission (optional) -->
+  <!-- extra recommended permission, we'd be able to collect device ringing breadcrumbs (PhoneStateBreadcrumbsIntegration) -->
+  <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
   <!--  if your minSdkVersion < 16, this would make usable on minSdkVersion >= 14-->
   <uses-sdk
     tools:overrideLibrary="io.sentry.android"/>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
extra recommended permission, we'd be able to collect device ringing breadcrumbs (PhoneStateBreadcrumbsIntegration)


## :bulb: Motivation and Context
so people are aware of it, older Android versions require this permission.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
