### PR TITLE
fix: init native libs if available on sdk init

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -1,8 +1,11 @@
 package io.sentry.android.core;
 
+import static io.sentry.android.core.NdkIntegration.SENTRY_NDK_CLASS_NAME;
+
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageInfo;
+import android.os.Build;
 import io.sentry.core.EnvelopeReader;
 import io.sentry.core.IEnvelopeReader;
 import io.sentry.core.ILogger;
@@ -47,6 +50,22 @@ final class AndroidOptionsInitializer {
       final @NotNull SentryAndroidOptions options,
       @NotNull Context context,
       final @NotNull ILogger logger) {
+    init(options, context, logger, new BuildInfoProvider());
+  }
+
+  /**
+   * Init method of the Android Options initializer
+   *
+   * @param options the SentryOptions
+   * @param context the Application context
+   * @param logger the ILogger interface
+   * @param buildInfoProvider the IBuildInfoProvider interface
+   */
+  static void init(
+      final @NotNull SentryAndroidOptions options,
+      @NotNull Context context,
+      final @NotNull ILogger logger,
+      final @NotNull IBuildInfoProvider buildInfoProvider) {
     Objects.requireNonNull(context, "The context is required.");
 
     // it returns null if ContextImpl, so let's check for nullability
@@ -67,12 +86,12 @@ final class AndroidOptionsInitializer {
 
     final IEnvelopeReader envelopeReader = new EnvelopeReader();
 
-    installDefaultIntegrations(context, options, envelopeReader);
+    installDefaultIntegrations(context, options, envelopeReader, buildInfoProvider);
 
     readDefaultOptionValues(options, context);
 
     options.addEventProcessor(
-        new DefaultAndroidEventProcessor(context, options, new BuildInfoProvider()));
+        new DefaultAndroidEventProcessor(context, options, buildInfoProvider));
 
     options.setSerializer(new AndroidSerializer(options.getLogger(), envelopeReader));
 
@@ -82,11 +101,14 @@ final class AndroidOptionsInitializer {
   private static void installDefaultIntegrations(
       final @NotNull Context context,
       final @NotNull SentryOptions options,
-      final @NotNull IEnvelopeReader envelopeReader) {
+      final @NotNull IEnvelopeReader envelopeReader,
+      final @NotNull IBuildInfoProvider buildInfoProvider) {
 
     // Integrations are registered in the same order. NDK before adding Watch outbox,
     // because sentry-native move files around and we don't want to watch that.
-    options.addIntegration(new NdkIntegration());
+    if (loadNdkIfAvailable(options, buildInfoProvider)) {
+      options.addIntegration(new NdkIntegration());
+    }
     options.addIntegration(EnvelopeFileObserverIntegration.getOutboxFileObserver(envelopeReader));
 
     // Send cached envelopes from outbox path
@@ -182,5 +204,33 @@ final class AndroidOptionsInitializer {
     } else {
       options.getLogger().log(SentryLevel.WARNING, "No session dir path is defined in options.");
     }
+  }
+
+  private static boolean isNdkAvailable(final @NotNull IBuildInfoProvider buildInfoProvider) {
+    return buildInfoProvider.getSdkInfoVersion() >= Build.VERSION_CODES.JELLY_BEAN;
+  }
+
+  private static boolean loadNdkIfAvailable(
+      final @NotNull SentryOptions options, final @NotNull IBuildInfoProvider buildInfoProvider) {
+    if (isNdkAvailable(buildInfoProvider)) {
+      try {
+        Class.forName(SENTRY_NDK_CLASS_NAME);
+        return true;
+      } catch (ClassNotFoundException e) {
+        options.setEnableNdk(false);
+        options.getLogger().log(SentryLevel.ERROR, "Failed to load SentryNdk.", e);
+      } catch (UnsatisfiedLinkError e) {
+        options.setEnableNdk(false);
+        options
+            .getLogger()
+            .log(SentryLevel.ERROR, "Failed to load (UnsatisfiedLinkError) SentryNdk.", e);
+      } catch (Throwable e) {
+        options.setEnableNdk(false);
+        options.getLogger().log(SentryLevel.ERROR, "Failed to initialize SentryNdk.", e);
+      }
+    } else {
+      options.setEnableNdk(false);
+    }
+    return false;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ILoadClass.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ILoadClass.java
@@ -1,0 +1,14 @@
+package io.sentry.android.core;
+
+/** An Adapter for making Class.forName testable */
+interface ILoadClass {
+
+  /**
+   * Try to load a class via reflection
+   *
+   * @param clazz the full class name
+   * @return a Class<?>
+   * @throws ClassNotFoundException if class is not found
+   */
+  Class<?> loadClass(String clazz) throws ClassNotFoundException;
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/LoadClass.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/LoadClass.java
@@ -1,0 +1,10 @@
+package io.sentry.android.core;
+
+import org.jetbrains.annotations.NotNull;
+
+final class LoadClass implements ILoadClass {
+  @Override
+  public @NotNull Class<?> loadClass(@NotNull String clazz) throws ClassNotFoundException {
+    return Class.forName(clazz);
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -1,31 +1,34 @@
 package io.sentry.android.core;
 
-import android.os.Build;
 import io.sentry.core.IHub;
 import io.sentry.core.Integration;
 import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
+import io.sentry.core.util.Objects;
 import java.lang.reflect.Method;
+import org.jetbrains.annotations.NotNull;
 
 /** Enables the NDK error reporting for Android */
 public final class NdkIntegration implements Integration {
-  private boolean isNdkAvailable() {
-    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
-  }
+
+  public static final String SENTRY_NDK_CLASS_NAME = "io.sentry.android.ndk.SentryNdk";
 
   @Override
-  public final void register(IHub hub, SentryOptions options) {
-    boolean enabled = options.isEnableNdk() && isNdkAvailable();
+  public final void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
+    Objects.requireNonNull(hub, "Hub is required");
+    Objects.requireNonNull(options, "SentryOptions is required");
+
+    final boolean enabled = options.isEnableNdk();
     options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration enabled: %s", enabled);
 
     // Note: `hub` isn't used here because the NDK integration writes files to disk which are picked
     // up by another integration (EnvelopeFileObserverIntegration).
     if (enabled) {
       try {
-        Class<?> cls = Class.forName("io.sentry.android.ndk.SentryNdk");
+        final Class<?> cls = Class.forName(SENTRY_NDK_CLASS_NAME);
 
-        Method method = cls.getMethod("init", SentryOptions.class);
-        Object[] args = new Object[1];
+        final Method method = cls.getMethod("init", SentryOptions.class);
+        final Object[] args = new Object[1];
         args[0] = options;
         method.invoke(null, args);
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -200,6 +200,7 @@ class AndroidOptionsInitializerTest {
         val buildInfo = mock<IBuildInfoProvider>()
         whenever(buildInfo.sdkInfoVersion).thenReturn(16)
 
+        // hard to test, lets just check that its not throwing anything
         AndroidOptionsInitializer.init(sentryOptions, mockContext, logger, buildInfo)
 
         verify(logger, never()).log(eq(SentryLevel.ERROR), eq("Failed to load (UnsatisfiedLinkError) SentryNdk."), any())

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ContextUtilsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ContextUtilsTest.kt
@@ -4,20 +4,26 @@ import android.app.Application
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.content.res.AssetManager
 import android.os.Bundle
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import java.io.File
+import java.io.FileNotFoundException
 
 object ContextUtilsTest {
     fun mockMetaData(mockContext: Context = createMockContext(), metaData: Bundle): Context {
         val mockPackageManager: PackageManager = mock()
         val mockApplicationInfo: ApplicationInfo = mock()
+        val assets: AssetManager = mock()
 
         whenever(mockContext.packageName).thenReturn("io.sentry.sample.test")
         whenever(mockContext.packageManager).thenReturn(mockPackageManager)
         whenever(mockPackageManager.getApplicationInfo(mockContext.packageName, PackageManager.GET_META_DATA))
             .thenReturn(mockApplicationInfo)
+        whenever(assets.open(any())).thenThrow(FileNotFoundException())
+        whenever(mockContext.assets).thenReturn(assets)
 
         mockApplicationInfo.metaData = metaData
         return mockContext

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -31,7 +31,9 @@ class ManifestMetadataReaderTest {
     @Test
     fun `applyMetadata won't throw exception`() {
         // tests for the returned boolean are in SentryInitProviderTest
-        val options = SentryAndroidOptions()
+        val options = SentryAndroidOptions().apply {
+            isDebug = true
+        }
 
         val context = ContextUtilsTest.createMockContext()
         ManifestMetadataReader.applyMetadata(context, options)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
@@ -9,6 +9,7 @@ import io.sentry.core.ILogger
 import io.sentry.core.SentryLevel
 import io.sentry.core.SentryOptions
 import kotlin.test.Test
+import kotlin.test.assertFalse
 
 class NdkIntegrationTest {
 
@@ -17,9 +18,30 @@ class NdkIntegrationTest {
         // hard to test, lets just check that its not throwing anything
         val integration = NdkIntegration()
         val logger = mock<ILogger>()
-        val options = SentryOptions()
-        options.setLogger(logger)
+        val options = SentryOptions().apply {
+            setLogger(logger)
+            isDebug = true
+        }
+        // it'll throw ClassNotFoundException because this class is not available on the test runtime.
         integration.register(mock(), options)
+        verify(logger, never()).log(eq(SentryLevel.ERROR), eq("Failed to load (UnsatisfiedLinkError) SentryNdk."), any())
         verify(logger, never()).log(eq(SentryLevel.ERROR), eq("Failed to initialize SentryNdk."), any())
+    }
+
+    @Test
+    fun `NdkIntegration won't init if ndk integration is disabled`() {
+        // hard to test, lets just check that its not throwing anything
+        val integration = NdkIntegration()
+        val logger = mock<ILogger>()
+        val options = SentryOptions().apply {
+            setLogger(logger)
+            isDebug = true
+            isEnableNdk = false
+        }
+        // it'll throw ClassNotFoundException because this class is not available on the test runtime.
+        integration.register(mock(), options)
+        verify(logger, never()).log(any(), any<String>(), any())
+        verify(logger, never()).log(any(), any())
+        assertFalse(options.isEnableNdk)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
@@ -30,7 +30,6 @@ class NdkIntegrationTest {
 
     @Test
     fun `NdkIntegration won't init if ndk integration is disabled`() {
-        // hard to test, lets just check that its not throwing anything
         val integration = NdkIntegration()
         val logger = mock<ILogger>()
         val options = SentryOptions().apply {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryNdk.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryNdk.kt
@@ -1,0 +1,11 @@
+package io.sentry.android.core
+
+import io.sentry.core.SentryOptions
+
+class SentryNdk {
+    companion object {
+        @JvmStatic
+        fun init(options: SentryOptions) {
+        }
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: init native libs if available on sdk init


## :bulb: Motivation and Context
one could init the SDK with an empty DSN and still load a native lib that depends on the libsentry, the libsentry was never initialized, now it is and it'll be NoOp as the Android SDK.


## :green_heart: How did you test it?
running on API 16 and 28, with and without an empty DSN.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
