### PR TITLE
Make JVM target explicit in sentry-core

### DIFF
--- a/sentry-core/build.gradle.kts
+++ b/sentry-core/build.gradle.kts
@@ -9,6 +9,15 @@ plugins {
     id(Config.QualityPlugins.gradleVersions)
 }
 
+configure<JavaPluginConvention> {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 dependencies {
     // Envelopes require JSON. Until a parse is done without GSON, we'll depend on it explicitly here
     implementation(Config.Libs.gson)


### PR DESCRIPTION
IDEA’s gradle support failed to inherit language/bytecode level from
parent project, causing mockito failures w/ 11 bytecode.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Explicitly set Java / JVM versions for the `sentry-core` subproject.

## :bulb: Motivation and Context

Technically it doesn’t fix a Sentry bug but rather papers over a bug in IDEA 2020.1.2 which makes tests fail from the IDE: It doesn’t detect the source & target JVM versions from the parent project. Then it generates JVM 11 bytecode, which our Mockito can’t handle.

## :green_heart: How did you test it?

Reimported in IDEA 2020.1.2 and saw that the JVM versions were now correct in the settings & the tests were green.

Had some tests that did not seem to deliver any result (green or red) in AS 4.0 but this did not change after reverting this change locally so it’s at least unrelated.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes - :warning: Build config only
- [X] All tests passing

## :crystal_ball: Next steps
