### PR TITLE
fix: negative session sequence if the date is before java date epoch

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidSerializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidSerializerTest.kt
@@ -373,7 +373,7 @@ class AndroidSerializerTest {
         assertEquals("123", expectedSession.distinctId)
         assertTrue(expectedSession.init!!)
         assertEquals("2020-02-07T14:16:00.000Z", DateUtils.getTimestamp(expectedSession.started))
-        assertEquals("2020-02-07T14:16:00.000Z", DateUtils.getTimestamp(expectedSession.timestamp))
+        assertEquals("2020-02-07T14:16:00.000Z", DateUtils.getTimestamp(expectedSession.timestamp!!))
         assertEquals(6000.toDouble(), expectedSession.duration)
         assertEquals(Session.State.Ok, expectedSession.status)
         assertEquals(2, expectedSession.errorCount())

--- a/sentry-core/src/test/java/io/sentry/core/SessionTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SessionTest.kt
@@ -1,5 +1,7 @@
 package io.sentry.core
 
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.protocol.User
 import java.util.Date
 import kotlin.test.Test
@@ -38,7 +40,7 @@ class SessionTest {
 
         session.end()
         assertNull(session.init)
-        assertTrue(session.timestamp >= timestamp)
+        assertTrue(session.timestamp!! >= timestamp)
         assertNotNull(session.duration)
         assertTrue(session.sequence!! > 0L)
     }
@@ -98,8 +100,20 @@ class SessionTest {
         session.update(null, null, true)
 
         assertNull(session.init)
-        assertTrue(session.timestamp >= timestamp)
+        assertTrue(session.timestamp!! >= timestamp)
         assertTrue(session.sequence!! > sequecence!!)
+    }
+
+    @Test
+    fun `Offset sequence if Date and Time is wrong and time is negative`() {
+        val user = User().apply {
+            ipAddress = "127.0.0.1"
+        }
+        val session = createSession(user)
+        val dateMock = mock<Date>()
+        whenever(dateMock.time).thenReturn(-1489552)
+        session.end(dateMock)
+        assertEquals(1489552, session.sequence)
     }
 
     private fun createSession(user: User = User()): Session {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: negative session sequence if the date is before java date epoch


## :bulb: Motivation and Context
often old emulators may have a date not set, which means it'll be January 1, 1970, 00:00:00 GMT
when converting timezones to UTC, it may give a wrong date, which should be offset to not be negative.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
