### PR TITLE
fix: clone session before sending to the transport

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Scope.java
+++ b/sentry-core/src/main/java/io/sentry/core/Scope.java
@@ -406,7 +406,8 @@ public final class Scope implements Cloneable {
           new Session(
               options.getDistinctId(), user, options.getEnvironment(), options.getRelease());
 
-      pair = new SessionPair(session, previousSession);
+      final Session previousClone = previousSession != null ? previousSession.clone() : null;
+      pair = new SessionPair(session.clone(), previousClone);
     }
     return pair;
   }
@@ -461,7 +462,7 @@ public final class Scope implements Cloneable {
     synchronized (sessionLock) {
       if (session != null) {
         session.end();
-        previousSession = session;
+        previousSession = session.clone();
         session = null;
       }
     }

--- a/sentry-core/src/main/java/io/sentry/core/Session.java
+++ b/sentry-core/src/main/java/io/sentry/core/Session.java
@@ -96,12 +96,12 @@ public final class Session {
     this(
         State.Ok,
         DateUtils.getCurrentDateTime(),
-        null,
+        DateUtils.getCurrentDateTime(),
         0,
         distinctId,
         UUID.randomUUID(),
         true,
-        0L,
+        null,
         null,
         (user != null ? user.getIpAddress() : null),
         null,
@@ -256,5 +256,28 @@ public final class Session {
       sequence = Math.abs(sequence);
     }
     return sequence;
+  }
+
+  /**
+   * Ctor copy of the Session
+   *
+   * @return a copy of the Session
+   */
+  @SuppressWarnings("MissingOverride")
+  public @NotNull Session clone() {
+    return new Session(
+        status,
+        started,
+        timestamp,
+        errorCount.get(),
+        distinctId,
+        sessionId,
+        init,
+        sequence,
+        duration,
+        ipAddress,
+        userAgent,
+        environment,
+        release);
   }
 }

--- a/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
@@ -459,12 +459,14 @@ class SentryClientTest {
     @Test
     fun `When event is Fatal or not handled, mark session as Crashed`() {
         val scope = Scope(fixture.sentryOptions)
-        val session = scope.startSession().current
+        scope.startSession().current
         val event = SentryEvent().apply {
             level = SentryLevel.FATAL
         }
         fixture.getSut().updateSessionData(event, null, scope)
-        assertEquals(Session.State.Crashed, session.status)
+        scope.withSession {
+            assertEquals(Session.State.Crashed, it!!.status)
+        }
     }
 
     @Test
@@ -480,25 +482,29 @@ class SentryClientTest {
     @Test
     fun `When event is Fatal, increase errorCount`() {
         val scope = Scope(fixture.sentryOptions)
-        val session = scope.startSession().current
+        scope.startSession().current
         val event = SentryEvent().apply {
             level = SentryLevel.FATAL
         }
         fixture.getSut().updateSessionData(event, null, scope)
-        assertEquals(1, session.errorCount())
+        scope.withSession {
+            assertEquals(1, it!!.errorCount())
+        }
     }
 
     @Test
     fun `When event is Errored, increase errorCount`() {
         val scope = Scope(fixture.sentryOptions)
-        val session = scope.startSession().current
+        scope.startSession().current
         val exceptions = mutableListOf<SentryException>()
         exceptions.add(SentryException())
         val event = SentryEvent().apply {
             setExceptions(exceptions)
         }
         fixture.getSut().updateSessionData(event, null, scope)
-        assertEquals(1, session.errorCount())
+        scope.withSession {
+            assertEquals(1, it!!.errorCount())
+        }
     }
 
     @Test
@@ -514,14 +520,16 @@ class SentryClientTest {
     @Test
     fun `When event has userAgent, set it into session`() {
         val scope = Scope(fixture.sentryOptions)
-        val session = scope.startSession().current
+        scope.startSession().current
         val event = SentryEvent().apply {
             request = Request()
             request.headers = mutableMapOf()
             request.headers["user-agent"] = "jamesBond"
         }
         fixture.getSut().updateSessionData(event, null, scope)
-        assertEquals("jamesBond", session.userAgent)
+        scope.withSession {
+            assertEquals("jamesBond", it!!.userAgent)
+        }
     }
 
     @Test
@@ -589,10 +597,12 @@ class SentryClientTest {
             level = SentryLevel.FATAL
         }
         val scope = Scope(fixture.sentryOptions)
-        val session = scope.startSession().current
+        scope.startSession().current
         sut.captureEvent(event, scope, null)
-        assertEquals(Session.State.Crashed, session.status)
-        assertEquals(1, session.errorCount())
+        scope.withSession {
+            assertEquals(Session.State.Crashed, it!!.status)
+            assertEquals(1, it.errorCount())
+        }
     }
 
     private fun createScope(): Scope {

--- a/sentry-core/src/test/java/io/sentry/core/SessionTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SessionTest.kt
@@ -7,6 +7,7 @@ import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -24,7 +25,7 @@ class SessionTest {
         assertEquals("distinctId", session.distinctId)
         assertEquals("127.0.0.1", session.ipAddress)
         assertTrue(session.init!!)
-        assertEquals(0L, session.sequence)
+        assertNull(session.sequence)
         assertNotNull(session.sessionId)
         assertNotNull(session.started)
         assertEquals(Session.State.Ok, session.status)
@@ -96,12 +97,11 @@ class SessionTest {
         }
         val session = createSession(user)
         val timestamp = session.started
-        val sequecence = session.sequence
         session.update(null, null, true)
 
         assertNull(session.init)
         assertTrue(session.timestamp!! >= timestamp)
-        assertTrue(session.sequence!! > sequecence!!)
+        assertNotNull(session.sequence)
     }
 
     @Test
@@ -114,6 +114,17 @@ class SessionTest {
         whenever(dateMock.time).thenReturn(-1489552)
         session.end(dateMock)
         assertEquals(1489552, session.sequence)
+    }
+
+    @Test
+    fun `Clone session returns a copy of the session`() {
+        val user = User().apply {
+            ipAddress = "127.0.0.1"
+        }
+        val session = createSession(user)
+        val clone = session.clone()
+
+        assertNotSame(clone, session)
     }
 
     private fun createSession(user: User = User()): Session {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: clone session before sending to the transport


## :bulb: Motivation and Context
if a session was mutated before sent and discarded, fields could be wrong as they are mutable.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
