### PR TITLE
fix: Timber adds breadcrumb even if event level is < minEventLevel

### DIFF
--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
@@ -171,28 +171,28 @@ class SentryTimberTreeTest {
 
     @Test
     fun `Tree adds a breadcrumb if min level is equal`() {
-        val sut = fixture.getSut(minEventLevel = SentryLevel.INFO)
+        val sut = fixture.getSut()
         sut.i(Throwable("test"))
         verify(fixture.hub).addBreadcrumb(any<Breadcrumb>())
     }
 
     @Test
     fun `Tree adds a breadcrumb if min level is higher`() {
-        val sut = fixture.getSut(minEventLevel = SentryLevel.INFO)
+        val sut = fixture.getSut()
         sut.e(Throwable("test"))
         verify(fixture.hub).addBreadcrumb(any<Breadcrumb>())
     }
 
     @Test
     fun `Tree won't add a breadcrumb if min level is lower`() {
-        val sut = fixture.getSut(minEventLevel = SentryLevel.DEBUG, minBreadcrumbLevel = SentryLevel.ERROR)
+        val sut = fixture.getSut(minBreadcrumbLevel = SentryLevel.ERROR)
         sut.i(Throwable("test"))
         verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>())
     }
 
     @Test
     fun `Tree adds a breadcrumb with given level`() {
-        val sut = fixture.getSut(minEventLevel = SentryLevel.INFO)
+        val sut = fixture.getSut()
         sut.e(Throwable("test"))
         verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals(SentryLevel.ERROR, it.level)
@@ -201,7 +201,7 @@ class SentryTimberTreeTest {
 
     @Test
     fun `Tree adds a breadcrumb with Timber category`() {
-        val sut = fixture.getSut(minEventLevel = SentryLevel.INFO)
+        val sut = fixture.getSut()
         sut.e(Throwable("test"))
         verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals("Timber", it.category)
@@ -210,7 +210,7 @@ class SentryTimberTreeTest {
 
     @Test
     fun `Tree adds a breadcrumb with exception message`() {
-        val sut = fixture.getSut(minEventLevel = SentryLevel.INFO)
+        val sut = fixture.getSut()
         sut.e(Throwable("test"))
         verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertTrue(it.message!!.contains("test"))


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: Timber adds breadcrumb even if event level is < minEventLevel


## :bulb: Motivation and Context
Sentry was adding breadcrumbs only if minEventLevel was >= level


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing


## :crystal_ball: Next steps
