### PR TITLE
fix: event.level fatal is not a crashed session

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
@@ -330,14 +330,11 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
   }
 
   /**
-   * Returns true if Level is Fatal or any exception was unhandled by the user.
+   * Returns true if any exception was unhandled by the user.
    *
    * @return true if its crashed or false otherwise
    */
   public boolean isCrashed() {
-    if (level == SentryLevel.FATAL) {
-      return true;
-    }
     if (exception != null) {
       for (SentryException e : exception.getValues()) {
         if (e.getMechanism() != null

--- a/sentry-core/src/test/java/io/sentry/core/SentryEventTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryEventTest.kt
@@ -40,13 +40,6 @@ class SentryEventTest {
     }
 
     @Test
-    fun `if level Fatal it should return isCrashed=true`() {
-        val event = SentryEvent()
-        event.level = SentryLevel.FATAL
-        assertTrue(event.isCrashed)
-    }
-
-    @Test
     fun `if mechanism is not handled, it should return isCrashed=true`() {
         val mechanism = Mechanism()
         mechanism.isHandled = false
@@ -58,11 +51,10 @@ class SentryEventTest {
     }
 
     @Test
-    fun `if mechanism is handled and level is not fatal, it should return isCrashed=false`() {
+    fun `if mechanism is handled, it should return isCrashed=false`() {
         val mechanism = Mechanism()
         mechanism.isHandled = true
         val event = SentryEvent()
-        event.level = SentryLevel.ERROR
         val factory = SentryExceptionFactory(mock())
         val sentryExceptions = factory.getSentryExceptions(ExceptionMechanismException(mechanism, Throwable(), Thread()))
         event.exceptions = sentryExceptions
@@ -70,13 +62,21 @@ class SentryEventTest {
     }
 
     @Test
-    fun `if mechanism nas not handled flag and level is not fatal, it should return isCrashed=false`() {
+    fun `if mechanism handled flag is null, it should return isCrashed=false`() {
         val mechanism = Mechanism()
         mechanism.isHandled = null
         val event = SentryEvent()
-        event.level = SentryLevel.ERROR
         val factory = SentryExceptionFactory(mock())
         val sentryExceptions = factory.getSentryExceptions(ExceptionMechanismException(mechanism, Throwable(), Thread()))
+        event.exceptions = sentryExceptions
+        assertFalse(event.isCrashed)
+    }
+
+    @Test
+    fun `if mechanism is not set, it should return isCrashed=false`() {
+        val event = SentryEvent()
+        val factory = SentryExceptionFactory(mock())
+        val sentryExceptions = factory.getSentryExceptions(RuntimeException(Throwable()))
         event.exceptions = sentryExceptions
         assertFalse(event.isCrashed)
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: event.level fatal is not a crashed session


## :bulb: Motivation and Context
only the mechanism.handled has the ability to end a session as crashed.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
