### PR TITLE
Call `Sentry#close` on JVM shutdown.

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import io.sentry.core.ILogger;
 import io.sentry.core.SendCachedEventFireAndForgetIntegration;
 import io.sentry.core.SendFireAndForgetEnvelopeSender;
+import io.sentry.core.SendFireAndForgetEventSender;
 import io.sentry.core.SentryLevel;
 import io.sentry.core.SentryOptions;
 import io.sentry.core.util.Objects;
@@ -114,6 +115,14 @@ final class AndroidOptionsInitializer {
       final @NotNull SentryOptions options,
       final @NotNull IBuildInfoProvider buildInfoProvider,
       final @NotNull ILoadClass loadClass) {
+
+    options.addIntegration(
+        new SendCachedEventFireAndForgetIntegration(
+            new SendFireAndForgetEventSender(() -> options.getCacheDirPath())));
+
+    options.addIntegration(
+        new SendCachedEventFireAndForgetIntegration(
+            new SendFireAndForgetEnvelopeSender(() -> options.getSessionsPath())));
 
     // Integrations are registered in the same order. NDK before adding Watch outbox,
     // because sentry-native move files around and we don't want to watch that.

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -13,6 +13,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.core.ILogger
 import io.sentry.core.MainEventProcessor
+import io.sentry.core.SendCachedEventFireAndForgetIntegration
 import io.sentry.core.SentryLevel
 import io.sentry.core.SentryOptions
 import java.io.File
@@ -266,6 +267,16 @@ class AndroidOptionsInitializerTest {
 
         AndroidOptionsInitializer.init(sentryOptions, mockContext)
         val actual = sentryOptions.integrations.firstOrNull { it is EnvelopeFileObserverIntegration }
+        assertNotNull(actual)
+    }
+
+    @Test
+    fun `SendCachedEventFireAndForgetIntegration added to integration list`() {
+        val sentryOptions = SentryAndroidOptions()
+        val mockContext = createMockContext()
+
+        AndroidOptionsInitializer.init(sentryOptions, mockContext)
+        val actual = sentryOptions.integrations.firstOrNull { it is SendCachedEventFireAndForgetIntegration }
         assertNotNull(actual)
     }
 

--- a/sentry-core/src/main/java/io/sentry/core/SendFireAndForgetEventSender.java
+++ b/sentry-core/src/main/java/io/sentry/core/SendFireAndForgetEventSender.java
@@ -1,14 +1,16 @@
 package io.sentry.core;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-final class SendFireAndForgetEventSender
+@ApiStatus.Internal
+public final class SendFireAndForgetEventSender
     implements SendCachedEventFireAndForgetIntegration.SendFireAndForgetFactory {
 
   private final @NotNull SendCachedEventFireAndForgetIntegration.SendFireAndForgetDirPath
       sendFireAndForgetDirPath;
 
-  SendFireAndForgetEventSender(
+  public SendFireAndForgetEventSender(
       final @NotNull SendCachedEventFireAndForgetIntegration.SendFireAndForgetDirPath
               sendFireAndForgetDirPath) {
     this.sendFireAndForgetDirPath = sendFireAndForgetDirPath;

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -1033,6 +1033,8 @@ public class SentryOptions {
     // if there's an error on the setup, we are able to capture it
     integrations.add(new UncaughtExceptionHandlerIntegration());
 
+    integrations.add(new ShutdownHookIntegration());
+
     eventProcessors.add(new MainEventProcessor(this));
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -1034,13 +1034,5 @@ public class SentryOptions {
     integrations.add(new UncaughtExceptionHandlerIntegration());
 
     eventProcessors.add(new MainEventProcessor(this));
-
-    integrations.add(
-        new SendCachedEventFireAndForgetIntegration(
-            new SendFireAndForgetEventSender(() -> getCacheDirPath())));
-
-    integrations.add(
-        new SendCachedEventFireAndForgetIntegration(
-            new SendFireAndForgetEnvelopeSender(() -> getSessionsPath())));
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -1033,7 +1033,7 @@ public class SentryOptions {
     // if there's an error on the setup, we are able to capture it
     integrations.add(new UncaughtExceptionHandlerIntegration());
 
-    integrations.add(new ShutdownHookIntegration());
+    integrations.add(new ShutdownHookIntegration(Runtime.getRuntime()));
 
     eventProcessors.add(new MainEventProcessor(this));
   }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -1033,7 +1033,7 @@ public class SentryOptions {
     // if there's an error on the setup, we are able to capture it
     integrations.add(new UncaughtExceptionHandlerIntegration());
 
-    integrations.add(new ShutdownHookIntegration(Runtime.getRuntime()));
+    integrations.add(new ShutdownHookIntegration());
 
     eventProcessors.add(new MainEventProcessor(this));
   }

--- a/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
@@ -1,0 +1,10 @@
+package io.sentry.core;
+
+/** Registers hook that closes {@link Sentry Sentry SDK} when main thread shuts down. */
+public final class ShutdownHookIntegration implements Integration {
+
+  @Override
+  public void register(IHub hub, SentryOptions options) {
+    Runtime.getRuntime().addShutdownHook(new Thread(Sentry::close));
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
@@ -1,10 +1,21 @@
 package io.sentry.core;
 
-/** Registers hook that closes {@link Sentry Sentry SDK} when main thread shuts down. */
+import io.sentry.core.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+/** Registers hook that closes {@link Hub} when main thread shuts down. */
 public final class ShutdownHookIntegration implements Integration {
 
+  private final @NotNull Runtime runtime;
+
+  public ShutdownHookIntegration(final @NotNull Runtime runtime) {
+    this.runtime = Objects.requireNonNull(runtime, "Runtime is required");
+  }
+
   @Override
-  public void register(IHub hub, SentryOptions options) {
-    Runtime.getRuntime().addShutdownHook(new Thread(Sentry::close));
+  public void register(@NotNull IHub hub, @NotNull SentryOptions options) {
+    Objects.requireNonNull(hub, "Hub is required");
+
+    runtime.addShutdownHook(new Thread(() -> hub.close()));
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
@@ -2,14 +2,20 @@ package io.sentry.core;
 
 import io.sentry.core.util.Objects;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 /** Registers hook that closes {@link Hub} when main thread shuts down. */
 public final class ShutdownHookIntegration implements Integration {
 
   private final @NotNull Runtime runtime;
 
+  @TestOnly
   public ShutdownHookIntegration(final @NotNull Runtime runtime) {
     this.runtime = Objects.requireNonNull(runtime, "Runtime is required");
+  }
+
+  public ShutdownHookIntegration() {
+    this(Runtime.getRuntime());
   }
 
   @Override

--- a/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
+++ b/sentry-core/src/main/java/io/sentry/core/ShutdownHookIntegration.java
@@ -13,7 +13,7 @@ public final class ShutdownHookIntegration implements Integration {
   }
 
   @Override
-  public void register(@NotNull IHub hub, @NotNull SentryOptions options) {
+  public void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
     Objects.requireNonNull(hub, "Hub is required");
 
     runtime.addShutdownHook(new Thread(() -> hub.close()));

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -45,6 +45,11 @@ class SentryOptionsTest {
     }
 
     @Test
+    fun `when options is initialized, integrations contain ShutdownHookIntegration`() {
+        assertTrue(SentryOptions().integrations.any { it is ShutdownHookIntegration })
+    }
+
+    @Test
     fun `when options is initialized, default maxBreadcrumb is 100`() =
         assertEquals(100, SentryOptions().maxBreadcrumbs)
 

--- a/sentry-core/src/test/java/io/sentry/core/ShutdownHookIntegrationTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/ShutdownHookIntegrationTest.kt
@@ -1,0 +1,19 @@
+package io.sentry.core
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import kotlin.test.Test
+
+class ShutdownHookIntegrationTest {
+
+    @Test
+    fun `registration attaches shutdown hook to runtime`() {
+        val runtime = mock<Runtime>()
+        val integration = ShutdownHookIntegration(runtime)
+
+        integration.register(NoOpHub.getInstance(), SentryOptions())
+
+        verify(runtime).addShutdownHook(any())
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
- Call `Sentry#close` on JVM shutdown - as a result flush all Sentry events that are in progress.
- Configure `SendCachedEventFireAndForgetIntegration` by default only for Android as for the console/server application cache does not apply


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this change, when Sentry is used in the console application, the main thread may finish before events are sent to Sentry and as a result no events are sent.

This idea was briefly discussed with @marandaneto and it's a subject for discussion - perhaps there is a better way to achieve the same result without attaching shutdown hook.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
