### PR TITLE
ref: Remove explicit client name from sample

### DIFF
--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -20,7 +20,6 @@ public class Main {
 
           // All events get assigned to the release. See more at https://docs.sentry.io/workflow/releases/
           options.setRelease("io.sentry.samples.console@3.0.0+1");
-          options.setSentryClientName("sentry.java/3.0.0");
 
           // Modifications to event before it goes out. Could replace the event altogether
           options.setBeforeSend(


### PR DESCRIPTION
Ideally we wouldn't have this public since it's not expected that users define the value they want for this.
We should add `sentry.java/version` by default in the core package, and override it if an outer package is wrapping it (i.e android).


But I'd just leave it out of the sample.