### PR TITLE
fix: converting UTC and ISO timestamp when missing Locale/TimeZone do not error

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -69,7 +69,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   @TestOnly static final String EMULATOR = "emulator";
 
   // it could also be a parameter and get from Sentry.init(...)
-  private static final Date appStartTime = DateUtils.getCurrentDateTime();
+  private static final @Nullable Date appStartTime = DateUtils.getCurrentDateTimeOrNull();
 
   @TestOnly final Context context;
 
@@ -397,10 +397,15 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   @SuppressWarnings("JdkObsolete")
-  private @NotNull Date getBootTime() {
-    // if user changes time, will give a wrong answer, consider ACTION_TIME_CHANGED
-    return DateUtils.getDateTime(
-        new Date(System.currentTimeMillis() - SystemClock.elapsedRealtime()));
+  private @Nullable Date getBootTime() {
+    try {
+      // if user changes time, will give a wrong answer, consider ACTION_TIME_CHANGED
+      return DateUtils.getDateTime(
+          new Date(System.currentTimeMillis() - SystemClock.elapsedRealtime()));
+    } catch (IllegalArgumentException e) {
+      logger.log(SentryLevel.ERROR, e, "Error getting the device's boot time.");
+    }
+    return null;
   }
 
   private @NotNull String getResolution(final @NotNull DisplayMetrics displayMetrics) {

--- a/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
+++ b/sentry-core/src/main/java/io/sentry/core/Breadcrumb.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.TestOnly;
 public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
 
   /** A timestamp representing when the breadcrumb occurred. */
-  private final @NotNull Date timestamp;
+  private final @Nullable Date timestamp;
 
   /** If a message is provided, its rendered as text and the whitespace is preserved. */
   private @Nullable String message;
@@ -39,13 +39,13 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
    *
    * @param timestamp the timestamp
    */
-  Breadcrumb(final @NotNull Date timestamp) {
+  Breadcrumb(final @Nullable Date timestamp) {
     this.timestamp = timestamp;
   }
 
   /** Breadcrumb ctor */
   public Breadcrumb() {
-    this(DateUtils.getCurrentDateTime());
+    this(DateUtils.getCurrentDateTimeOrNull());
   }
 
   /**

--- a/sentry-core/src/main/java/io/sentry/core/DateUtils.java
+++ b/sentry-core/src/main/java/io/sentry/core/DateUtils.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Utilities to deal with dates */
 @ApiStatus.Internal
@@ -26,7 +27,7 @@ public final class DateUtils {
    */
   public static @NotNull String getTimestampIsoFormat(final @NotNull Date date) {
     final TimeZone tz = TimeZone.getTimeZone(UTC);
-    final DateFormat df = new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.US);
+    final DateFormat df = new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
     df.setTimeZone(tz);
     return df.format(date);
   }
@@ -37,9 +38,23 @@ public final class DateUtils {
    * @return the ISO UTC date and time
    */
   @SuppressWarnings("JdkObsolete")
-  public static @NotNull Date getCurrentDateTime() {
+  public static @NotNull Date getCurrentDateTime() throws IllegalArgumentException {
     final String timestampIsoFormat = getTimestampIsoFormat(new Date());
     return getDateTime(timestampIsoFormat);
+  }
+
+  /**
+   * Get the current date and time as ISO UTC or null if not available
+   *
+   * @return the ISO UTC date and time or null
+   */
+  public static @Nullable Date getCurrentDateTimeOrNull() throws IllegalArgumentException {
+    try {
+      return getCurrentDateTime();
+    } catch (IllegalArgumentException ignored) {
+      // error getting current device's timestamp due to eg locale problems
+    }
+    return null;
   }
 
   /**
@@ -51,11 +66,11 @@ public final class DateUtils {
   public static @NotNull Date getDateTime(final @NotNull String timestamp)
       throws IllegalArgumentException {
     try {
-      return new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.US).parse(timestamp);
+      return new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT).parse(timestamp);
     } catch (ParseException e) {
       try {
         // to keep compatibility with older envelopes
-        return new SimpleDateFormat(ISO_FORMAT, Locale.US).parse(timestamp);
+        return new SimpleDateFormat(ISO_FORMAT, Locale.ROOT).parse(timestamp);
       } catch (ParseException ignored) {
         // invalid timestamp format
       }
@@ -90,7 +105,7 @@ public final class DateUtils {
    * @return the ISO formatted date with millis precision.
    */
   public static @NotNull String getTimestamp(final @NotNull Date date) {
-    final DateFormat df = new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.US);
+    final DateFormat df = new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
     return df.format(date);
   }
 
@@ -100,7 +115,8 @@ public final class DateUtils {
    * @param date the Date with local timezone
    * @return the Date UTC timezone
    */
-  public static @NotNull Date getDateTime(final @NotNull Date date) {
+  public static @NotNull Date getDateTime(final @NotNull Date date)
+      throws IllegalArgumentException {
     final String timestampIsoFormat = getTimestampIsoFormat(date);
     return getDateTime(timestampIsoFormat);
   }

--- a/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryEvent.java
@@ -49,7 +49,7 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
   }
 
   public SentryEvent() {
-    this(new SentryId(), DateUtils.getCurrentDateTime());
+    this(new SentryId(), DateUtils.getCurrentDateTimeOrNull());
   }
 
   @TestOnly

--- a/sentry-core/src/main/java/io/sentry/core/Session.java
+++ b/sentry-core/src/main/java/io/sentry/core/Session.java
@@ -95,8 +95,8 @@ public final class Session {
       final @NotNull String release) {
     this(
         State.Ok,
-        DateUtils.getCurrentDateTime(),
-        DateUtils.getCurrentDateTime(),
+        DateUtils.getCurrentDateTimeOrNull(),
+        DateUtils.getCurrentDateTimeOrNull(),
         0,
         distinctId,
         UUID.randomUUID(),
@@ -166,7 +166,7 @@ public final class Session {
 
   /** Ends a session and update its values */
   public void end() {
-    end(DateUtils.getCurrentDateTime());
+    end(DateUtils.getCurrentDateTimeOrNull());
   }
 
   /**
@@ -186,11 +186,13 @@ public final class Session {
       if (timestamp != null) {
         this.timestamp = timestamp;
       } else {
-        this.timestamp = DateUtils.getCurrentDateTime();
+        this.timestamp = DateUtils.getCurrentDateTimeOrNull();
       }
 
-      duration = calculateDurationTime(this.timestamp);
-      sequence = getSequenceTimestamp(this.timestamp);
+      if (this.timestamp != null) {
+        duration = calculateDurationTime(this.timestamp);
+        sequence = getSequenceTimestamp(this.timestamp);
+      }
     }
   }
 
@@ -234,8 +236,10 @@ public final class Session {
 
       if (sessionHasBeenUpdated) {
         init = null;
-        timestamp = DateUtils.getCurrentDateTime();
-        sequence = getSequenceTimestamp(timestamp);
+        timestamp = DateUtils.getCurrentDateTimeOrNull();
+        if (timestamp != null) {
+          sequence = getSequenceTimestamp(timestamp);
+        }
       }
       return sessionHasBeenUpdated;
     }

--- a/sentry-core/src/main/java/io/sentry/core/SessionAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/SessionAdapter.java
@@ -205,7 +205,8 @@ public final class SessionAdapter extends TypeAdapter<Session> {
         release);
   }
 
-  private @Nullable Date converTimeStamp(final @NotNull String timestamp, final @NotNull String field) {
+  private @Nullable Date converTimeStamp(
+      final @NotNull String timestamp, final @NotNull String field) {
     try {
       return DateUtils.getDateTime(timestamp);
     } catch (IllegalArgumentException e) {

--- a/sentry-core/src/main/java/io/sentry/core/SessionAdapter.java
+++ b/sentry-core/src/main/java/io/sentry/core/SessionAdapter.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.UUID;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class SessionAdapter extends TypeAdapter<Session> {
@@ -133,7 +134,7 @@ public final class SessionAdapter extends TypeAdapter<Session> {
           init = reader.nextBoolean();
           break;
         case "started":
-          started = DateUtils.getDateTime(reader.nextString());
+          started = converTimeStamp(reader.nextString(), "started");
           break;
         case "status":
           status = Session.State.valueOf(StringUtils.capitalize(reader.nextString()));
@@ -148,7 +149,7 @@ public final class SessionAdapter extends TypeAdapter<Session> {
           duration = reader.nextDouble();
           break;
         case "timestamp":
-          timestamp = DateUtils.getDateTime(reader.nextString());
+          timestamp = converTimeStamp(reader.nextString(), "timestamp");
           break;
         case "attrs":
           {
@@ -202,5 +203,14 @@ public final class SessionAdapter extends TypeAdapter<Session> {
         userAgent,
         environment,
         release);
+  }
+
+  private @Nullable Date converTimeStamp(final @NotNull String timestamp, final @NotNull String field) {
+    try {
+      return DateUtils.getDateTime(timestamp);
+    } catch (IllegalArgumentException e) {
+      logger.log(SentryLevel.ERROR, e, "Error converting session (%s) field.", field);
+    }
+    return null;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
+++ b/sentry-core/src/main/java/io/sentry/core/cache/SessionCache.java
@@ -193,6 +193,8 @@ public final class SessionCache implements IEnvelopeCache {
       return DateUtils.getDateTime(timestamp);
     } catch (IOException e) {
       options.getLogger().log(ERROR, "Error reading the crash marker file.", e);
+    } catch (IllegalArgumentException e) {
+      options.getLogger().log(SentryLevel.ERROR, e, "Error converting the crash timestamp.");
     }
     return null;
   }

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -18,7 +18,8 @@ public class Main {
           // your Sentry project/dashboard
           options.setDsn("https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954");
 
-          // All events get assigned to the release. See more at https://docs.sentry.io/workflow/releases/
+          // All events get assigned to the release. See more at
+          // https://docs.sentry.io/workflow/releases/
           options.setRelease("io.sentry.samples.console@3.0.0+1");
 
           // Modifications to event before it goes out. Could replace the event altogether
@@ -50,9 +51,13 @@ public class Main {
           options.setDebug(true);
           // To change the verbosity, use:
           // By default it's DEBUG.
-          options.setDiagnosticLevel(SentryLevel.ERROR); //  A good option to have SDK debug log in prod is to use only level ERROR here.
+          options.setDiagnosticLevel(
+              SentryLevel
+                  .ERROR); //  A good option to have SDK debug log in prod is to use only level
+          // ERROR here.
 
-          // Exclude frames from some packages from being "inApp" so are hidden by default in Sentry UI:
+          // Exclude frames from some packages from being "inApp" so are hidden by default in Sentry
+          // UI:
           options.addInAppExclude("org.jboss");
         });
 
@@ -110,7 +115,8 @@ public class Main {
       Sentry.captureEvent(event, SentryLevel.DEBUG);
     }
 
-    // All events that have not been sent yet are being flushed on JVM exit. Events can be also flushed manually:
+    // All events that have not been sent yet are being flushed on JVM exit. Events can be also
+    // flushed manually:
     // Sentry.close();
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: converting UTC and ISO timestamp if missing Locale or time zones.


## :bulb: Motivation and Context
Andromax G36C1H
Smartfren Andromax AD6B1H
Andromax C46B2H

devices have problems with getting US locale or UTC/GTM time zones.


## :green_heart: How did you test it?
I can't really test it, I don't have those devices or found emulators.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
