### PR TITLE
Set `SdkVersion` in default `SentryOptions` created in sentry-core module

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -5,6 +5,8 @@ object Config {
     object BuildPlugins {
         val androidGradle = "com.android.tools.build:gradle:4.0.1"
         val kotlinGradlePlugin = "gradle-plugin"
+        val buildConfig = "com.github.gmazzo.buildconfig"
+        val buildConfigVersion = "2.0.2"
     }
 
     object Android {

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -60,8 +60,8 @@ object Config {
     }
 
     object Sentry {
-        val SENTRY_CLIENT_NAME = "sentry.java"
-        val SENTRY_ANDROID_CLIENT_NAME = "$SENTRY_CLIENT_NAME.android"
+        val SENTRY_JAVA_CLIENT_NAME = "sentry.java"
+        val SENTRY_ANDROID_CLIENT_NAME = "$SENTRY_JAVA_CLIENT_NAME.android"
         val group = "io.sentry"
         val description = "SDK for sentry.io"
         val website = "https://sentry.io"

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -60,8 +60,8 @@ object Config {
     }
 
     object Sentry {
-        val SENTRY_JAVA_CLIENT_NAME = "sentry.java"
-        val SENTRY_ANDROID_CLIENT_NAME = "$SENTRY_JAVA_CLIENT_NAME.android"
+        val SENTRY_JAVA_SDK_NAME = "sentry.java"
+        val SENTRY_ANDROID_SDK_NAME = "$SENTRY_JAVA_SDK_NAME.android"
         val group = "io.sentry"
         val description = "SDK for sentry.io"
         val website = "https://sentry.io"

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -60,7 +60,8 @@ object Config {
     }
 
     object Sentry {
-        val SENTRY_CLIENT_NAME = "sentry.java.android"
+        val SENTRY_CLIENT_NAME = "sentry.java"
+        val SENTRY_ANDROID_CLIENT_NAME = "$SENTRY_CLIENT_NAME.android"
         val group = "io.sentry"
         val description = "SDK for sentry.io"
         val website = "https://sentry.io"

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -23,7 +23,7 @@ android {
         versionName = project.version.toString()
         versionCode = project.properties[Config.Sentry.buildVersionCodeProp].toString().toInt()
 
-        buildConfigField("String", "SENTRY_CLIENT_NAME", "\"${Config.Sentry.SENTRY_ANDROID_CLIENT_NAME}\"")
+        buildConfigField("String", "SENTRY_ANDROID_SDK_NAME", "\"${Config.Sentry.SENTRY_ANDROID_SDK_NAME}\"")
     }
 
     buildTypes {

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -23,7 +23,7 @@ android {
         versionName = project.version.toString()
         versionCode = project.properties[Config.Sentry.buildVersionCodeProp].toString().toInt()
 
-        buildConfigField("String", "SENTRY_CLIENT_NAME", "\"${Config.Sentry.SENTRY_CLIENT_NAME}\"")
+        buildConfigField("String", "SENTRY_CLIENT_NAME", "\"${Config.Sentry.SENTRY_ANDROID_CLIENT_NAME}\"")
     }
 
     buildTypes {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -35,7 +35,7 @@ public final class SentryAndroidOptions extends SentryOptions {
   private boolean enableAppComponentBreadcrumbs = true;
 
   public SentryAndroidOptions() {
-    setSentryClientName(BuildConfig.SENTRY_CLIENT_NAME + "/" + BuildConfig.VERSION_NAME);
+    setSentryClientName(BuildConfig.SENTRY_ANDROID_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());
   }
 
@@ -46,7 +46,7 @@ public final class SentryAndroidOptions extends SentryOptions {
       sdkVersion = new SdkVersion();
     }
 
-    sdkVersion.setName(BuildConfig.SENTRY_CLIENT_NAME);
+    sdkVersion.setName(BuildConfig.SENTRY_ANDROID_SDK_NAME);
     String version = BuildConfig.VERSION_NAME;
     sdkVersion.setVersion(version);
     sdkVersion.addPackage("maven:sentry-android-core", version);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -40,7 +40,11 @@ public final class SentryAndroidOptions extends SentryOptions {
   }
 
   private @NotNull SdkVersion createSdkVersion() {
-    final SdkVersion sdkVersion = getSdkVersion() != null ? getSdkVersion() : new SdkVersion();
+    SdkVersion sdkVersion = getSdkVersion();
+
+    if (sdkVersion == null) {
+      sdkVersion = new SdkVersion();
+    }
 
     sdkVersion.setName(BuildConfig.SENTRY_CLIENT_NAME);
     String version = BuildConfig.VERSION_NAME;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -40,16 +40,12 @@ public final class SentryAndroidOptions extends SentryOptions {
   }
 
   private @NotNull SdkVersion createSdkVersion() {
-    final SdkVersion sdkVersion = new SdkVersion();
+    final SdkVersion sdkVersion = getSdkVersion() != null ? getSdkVersion() : new SdkVersion();
 
     sdkVersion.setName(BuildConfig.SENTRY_CLIENT_NAME);
     String version = BuildConfig.VERSION_NAME;
     sdkVersion.setVersion(version);
-
-    // add 2 default packages
     sdkVersion.addPackage("maven:sentry-android-core", version);
-    // TODO: sentry-core should add itself as the version may mismatch
-    sdkVersion.addPackage("maven:sentry-core", version);
 
     return sdkVersion;
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -11,7 +11,7 @@ class SentryAndroidOptionsTest {
     fun `init should set clientName`() {
         val sentryOptions = SentryAndroidOptions()
 
-        val clientName = "${BuildConfig.SENTRY_CLIENT_NAME}/${BuildConfig.VERSION_NAME}"
+        val clientName = "${BuildConfig.SENTRY_ANDROID_SDK_NAME}/${BuildConfig.VERSION_NAME}"
 
         assertEquals(clientName, sentryOptions.sentryClientName)
     }
@@ -22,7 +22,7 @@ class SentryAndroidOptionsTest {
         assertNotNull(sentryOptions.sdkVersion)
         val sdkVersion = sentryOptions.sdkVersion!!
 
-        assertEquals(BuildConfig.SENTRY_CLIENT_NAME, sdkVersion.name)
+        assertEquals(BuildConfig.SENTRY_ANDROID_SDK_NAME, sdkVersion.name)
         assertEquals(BuildConfig.VERSION_NAME, sdkVersion.version)
 
         assertTrue(sdkVersion.packages!!.any {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -26,12 +26,12 @@ class SentryAndroidOptionsTest {
         assertEquals(BuildConfig.VERSION_NAME, sdkVersion.version)
 
         assertTrue(sdkVersion.packages!!.any {
-            it.name == "maven:sentry-android-core"
+            it.name == "maven:sentry-android-core" &&
             it.version == BuildConfig.VERSION_NAME
         })
 
         assertTrue(sdkVersion.packages!!.any {
-            it.name == "maven:sentry-core"
+            it.name == "maven:sentry-core" &&
             it.version == BuildConfig.VERSION_NAME
         })
     }

--- a/sentry-android-ndk/src/test/java/io/sentry/android/ndk/SentryNdkUtilTest.kt
+++ b/sentry-android-ndk/src/test/java/io/sentry/android/ndk/SentryNdkUtilTest.kt
@@ -1,7 +1,6 @@
 package io.sentry.android.ndk
 
 import io.sentry.core.SentryOptions
-import io.sentry.core.protocol.SdkVersion
 import kotlin.test.Test
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -10,9 +9,7 @@ class SentryNdkUtilTest {
 
     @Test
     fun `SentryNdk adds the Ndk package into the package list`() {
-        val options = SentryOptions().apply {
-            sdkVersion = SdkVersion()
-        }
+        val options = SentryOptions()
         SentryNdkUtil.addPackage(options.sdkVersion)
         assertTrue(options.sdkVersion!!.packages!!.any {
             it.name == "maven:sentry-android-ndk"
@@ -22,7 +19,9 @@ class SentryNdkUtilTest {
 
     @Test
     fun `SentryNdk do not add the Ndk package into the package list`() {
-        val options = SentryOptions()
+        val options = SentryOptions().apply {
+            sdkVersion = null
+        }
         SentryNdkUtil.addPackage(options.sdkVersion)
 
         assertNull(options.sdkVersion?.packages)

--- a/sentry-core/build.gradle.kts
+++ b/sentry-core/build.gradle.kts
@@ -69,7 +69,7 @@ tasks {
 buildConfig {
     useJavaOutput()
     packageName("io.sentry.core")
-    buildConfigField("String", "SENTRY_CLIENT_NAME", "\"${Config.Sentry.SENTRY_JAVA_CLIENT_NAME}\"")
+    buildConfigField("String", "SENTRY_JAVA_SDK_NAME", "\"${Config.Sentry.SENTRY_JAVA_SDK_NAME}\"")
     buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
 }
 

--- a/sentry-core/build.gradle.kts
+++ b/sentry-core/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id(Config.QualityPlugins.errorProne)
     id(Config.Deploy.novodaBintray)
     id(Config.QualityPlugins.gradleVersions)
+    id(Config.BuildPlugins.buildConfig) version Config.BuildPlugins.buildConfigVersion
 }
 
 configure<JavaPluginConvention> {
@@ -63,6 +64,18 @@ tasks {
         dependsOn(jacocoTestCoverageVerification)
         dependsOn(jacocoTestReport)
     }
+}
+
+buildConfig {
+    useJavaOutput()
+    packageName("io.sentry.core")
+    buildConfigField("String", "SDK_NAME", "\"${project.name}\"")
+    buildConfigField("String", "SDK_VERSION", "\"${project.version}\"")
+}
+
+val generateBuildConfig by tasks
+tasks.withType<JavaCompile>().configureEach {
+    dependsOn(generateBuildConfig)
 }
 
 //TODO: move thse blocks to parent gradle file, DRY

--- a/sentry-core/build.gradle.kts
+++ b/sentry-core/build.gradle.kts
@@ -69,7 +69,7 @@ tasks {
 buildConfig {
     useJavaOutput()
     packageName("io.sentry.core")
-    buildConfigField("String", "SDK_NAME", "\"${project.name}\"")
+    buildConfigField("String", "SDK_NAME", "\"${Config.Sentry.SENTRY_CLIENT_NAME}\"")
     buildConfigField("String", "SDK_VERSION", "\"${project.version}\"")
 }
 

--- a/sentry-core/build.gradle.kts
+++ b/sentry-core/build.gradle.kts
@@ -69,8 +69,8 @@ tasks {
 buildConfig {
     useJavaOutput()
     packageName("io.sentry.core")
-    buildConfigField("String", "SDK_NAME", "\"${Config.Sentry.SENTRY_CLIENT_NAME}\"")
-    buildConfigField("String", "SDK_VERSION", "\"${project.version}\"")
+    buildConfigField("String", "SENTRY_CLIENT_NAME", "\"${Config.Sentry.SENTRY_JAVA_CLIENT_NAME}\"")
+    buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
 }
 
 val generateBuildConfig by tasks

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -1036,5 +1036,18 @@ public class SentryOptions {
     integrations.add(new ShutdownHookIntegration());
 
     eventProcessors.add(new MainEventProcessor(this));
+
+    setSdkVersion(createSdkVersion());
+  }
+
+  private @NotNull SdkVersion createSdkVersion() {
+    final SdkVersion sdkVersion = new SdkVersion();
+
+    sdkVersion.setName(BuildConfig.SDK_NAME);
+    String version = BuildConfig.SDK_VERSION;
+    sdkVersion.setVersion(version);
+    sdkVersion.addPackage("maven:sentry-core", version);
+
+    return sdkVersion;
   }
 }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -1037,14 +1037,14 @@ public class SentryOptions {
 
     eventProcessors.add(new MainEventProcessor(this));
 
-    setSentryClientName(BuildConfig.SENTRY_CLIENT_NAME + "/" + BuildConfig.VERSION_NAME);
+    setSentryClientName(BuildConfig.SENTRY_JAVA_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());
   }
 
   private @NotNull SdkVersion createSdkVersion() {
     final SdkVersion sdkVersion = new SdkVersion();
 
-    sdkVersion.setName(BuildConfig.SENTRY_CLIENT_NAME);
+    sdkVersion.setName(BuildConfig.SENTRY_JAVA_SDK_NAME);
     String version = BuildConfig.VERSION_NAME;
     sdkVersion.setVersion(version);
     sdkVersion.addPackage("maven:sentry-core", version);

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -1037,14 +1037,15 @@ public class SentryOptions {
 
     eventProcessors.add(new MainEventProcessor(this));
 
+    setSentryClientName(BuildConfig.SENTRY_CLIENT_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());
   }
 
   private @NotNull SdkVersion createSdkVersion() {
     final SdkVersion sdkVersion = new SdkVersion();
 
-    sdkVersion.setName(BuildConfig.SDK_NAME);
-    String version = BuildConfig.SDK_VERSION;
+    sdkVersion.setName(BuildConfig.SENTRY_CLIENT_NAME);
+    String version = BuildConfig.VERSION_NAME;
     sdkVersion.setVersion(version);
     sdkVersion.addPackage("maven:sentry-core", version);
 

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -131,12 +131,21 @@ class SentryOptionsTest {
         assertNotNull(sentryOptions.sdkVersion)
         val sdkVersion = sentryOptions.sdkVersion!!
 
-        assertEquals(BuildConfig.SDK_NAME, sdkVersion.name)
-        assertEquals(BuildConfig.SDK_VERSION, sdkVersion.version)
+        assertEquals(BuildConfig.SENTRY_CLIENT_NAME, sdkVersion.name)
+        assertEquals(BuildConfig.VERSION_NAME, sdkVersion.version)
 
         assertTrue(sdkVersion.packages!!.any {
             it.name == "maven:sentry-core" &&
-            it.version == BuildConfig.SDK_VERSION
+            it.version == BuildConfig.VERSION_NAME
         })
+    }
+
+    @Test
+    fun `init should set clientName`() {
+        val sentryOptions = SentryOptions()
+
+        val clientName = "${BuildConfig.SENTRY_CLIENT_NAME}/${BuildConfig.VERSION_NAME}"
+
+        assertEquals(clientName, sentryOptions.sentryClientName)
     }
 }

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -124,4 +124,19 @@ class SentryOptionsTest {
         val options = SentryOptions()
         assertNotNull(options.executorService)
     }
+
+    @Test
+    fun `init should set SdkVersion`() {
+        val sentryOptions = SentryOptions()
+        assertNotNull(sentryOptions.sdkVersion)
+        val sdkVersion = sentryOptions.sdkVersion!!
+
+        assertEquals(BuildConfig.SDK_NAME, sdkVersion.name)
+        assertEquals(BuildConfig.SDK_VERSION, sdkVersion.version)
+
+        assertTrue(sdkVersion.packages!!.any {
+            it.name == "maven:sentry-core"
+            it.version == BuildConfig.SDK_VERSION
+        })
+    }
 }

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -135,7 +135,7 @@ class SentryOptionsTest {
         assertEquals(BuildConfig.SDK_VERSION, sdkVersion.version)
 
         assertTrue(sdkVersion.packages!!.any {
-            it.name == "maven:sentry-core"
+            it.name == "maven:sentry-core" &&
             it.version == BuildConfig.SDK_VERSION
         })
     }

--- a/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryOptionsTest.kt
@@ -131,7 +131,7 @@ class SentryOptionsTest {
         assertNotNull(sentryOptions.sdkVersion)
         val sdkVersion = sentryOptions.sdkVersion!!
 
-        assertEquals(BuildConfig.SENTRY_CLIENT_NAME, sdkVersion.name)
+        assertEquals(BuildConfig.SENTRY_JAVA_SDK_NAME, sdkVersion.name)
         assertEquals(BuildConfig.VERSION_NAME, sdkVersion.version)
 
         assertTrue(sdkVersion.packages!!.any {
@@ -144,7 +144,7 @@ class SentryOptionsTest {
     fun `init should set clientName`() {
         val sentryOptions = SentryOptions()
 
-        val clientName = "${BuildConfig.SENTRY_CLIENT_NAME}/${BuildConfig.VERSION_NAME}"
+        val clientName = "${BuildConfig.SENTRY_JAVA_SDK_NAME}/${BuildConfig.VERSION_NAME}"
 
         assertEquals(clientName, sentryOptions.sentryClientName)
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Sets `SdkVersion` in `SentryOptions` created in sentry-core module from build-time generated class `BuildConfig`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/getsentry/sentry-java/issues/873

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes