### PR TITLE
make EventProcessor.process Nullable

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/EventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/EventProcessor.java
@@ -3,5 +3,6 @@ package io.sentry.core;
 import org.jetbrains.annotations.Nullable;
 
 public interface EventProcessor {
+  @Nullable
   SentryEvent process(SentryEvent event, @Nullable Object hint);
 }

--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -6,6 +6,7 @@ import io.sentry.core.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
@@ -38,7 +39,7 @@ public final class MainEventProcessor implements EventProcessor {
   }
 
   @Override
-  public SentryEvent process(SentryEvent event, @Nullable Object hint) {
+  public @NotNull SentryEvent process(SentryEvent event, @Nullable Object hint) {
     if (event.getPlatform() == null) {
       // this actually means JVM related.
       event.setPlatform("java");


### PR DESCRIPTION
Null return is used when the event should be dropped. This aligns with the current handling in `sentry-android` code and also with the Sentry unified API definition of event processors.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Alignment with unified API https://develop.sentry.dev/sdk/unified-api/#terminology

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
