### PR TITLE
Set SDK version in `MainEventProcessor`.

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -104,8 +104,7 @@ final class AndroidOptionsInitializer {
 
     readDefaultOptionValues(options, context);
 
-    options.addEventProcessor(
-        new DefaultAndroidEventProcessor(context, options, buildInfoProvider));
+    options.addEventProcessor(new DefaultAndroidEventProcessor(context, logger, buildInfoProvider));
 
     options.setTransportGate(new AndroidTransportGate(context, options.getLogger()));
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -27,7 +27,6 @@ import io.sentry.core.EventProcessor;
 import io.sentry.core.ILogger;
 import io.sentry.core.SentryEvent;
 import io.sentry.core.SentryLevel;
-import io.sentry.core.SentryOptions;
 import io.sentry.core.protocol.App;
 import io.sentry.core.protocol.DebugImage;
 import io.sentry.core.protocol.DebugMeta;
@@ -73,8 +72,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   @TestOnly final Context context;
 
-  private final SentryOptions options;
-
   @TestOnly final Future<Map<String, Object>> contextData;
 
   private final @NotNull IBuildInfoProvider buildInfoProvider;
@@ -84,23 +81,18 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   public DefaultAndroidEventProcessor(
       final @NotNull Context context,
-      final @NotNull SentryOptions options,
+      final @NotNull ILogger logger,
       final @NotNull IBuildInfoProvider buildInfoProvider) {
-    this(
-        context,
-        options,
-        buildInfoProvider,
-        new RootChecker(context, buildInfoProvider, options.getLogger()));
+    this(context, logger, buildInfoProvider, new RootChecker(context, buildInfoProvider, logger));
   }
 
   DefaultAndroidEventProcessor(
       final @NotNull Context context,
-      final @NotNull SentryOptions options,
+      final @NotNull ILogger logger,
       final @NotNull IBuildInfoProvider buildInfoProvider,
       final @NotNull RootChecker rootChecker) {
     this.context = Objects.requireNonNull(context, "The application context is required.");
-    this.options = Objects.requireNonNull(options, "The SentryOptions is required.");
-    this.logger = Objects.requireNonNull(options.getLogger(), "The Logger is required.");
+    this.logger = Objects.requireNonNull(logger, "The Logger is required.");
     this.buildInfoProvider =
         Objects.requireNonNull(buildInfoProvider, "The BuildInfoProvider is required.");
     this.rootChecker = Objects.requireNonNull(rootChecker, "The RootChecker is required.");
@@ -173,9 +165,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     if (event.getDebugMeta() == null) {
       event.setDebugMeta(getDebugMeta());
-    }
-    if (event.getSdk() == null) {
-      event.setSdk(options.getSdkVersion());
     }
 
     PackageInfo packageInfo = ContextUtils.getPackageInfo(context, logger);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -15,6 +15,7 @@ import io.sentry.android.core.DefaultAndroidEventProcessor.KERNEL_VERSION
 import io.sentry.android.core.DefaultAndroidEventProcessor.PROGUARD_UUID
 import io.sentry.android.core.DefaultAndroidEventProcessor.ROOTED
 import io.sentry.core.DiagnosticLogger
+import io.sentry.core.ILogger
 import io.sentry.core.SentryEvent
 import io.sentry.core.SentryLevel
 import io.sentry.core.SentryOptions
@@ -27,7 +28,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 
@@ -56,7 +56,7 @@ class DefaultAndroidEventProcessorTest {
 
     @Test
     fun `when instance is created, application context reference is stored`() {
-        val sut = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo)
+        val sut = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
 
         assertEquals(sut.context, context)
     }
@@ -64,7 +64,7 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `when null context is provided, invalid argument is thrown`() {
         val clazz = Class.forName("io.sentry.android.core.DefaultAndroidEventProcessor")
-        val ctor = clazz.getConstructor(Context::class.java, SentryOptions::class.java, IBuildInfoProvider::class.java)
+        val ctor = clazz.getConstructor(Context::class.java, ILogger::class.java, IBuildInfoProvider::class.java)
         val params = arrayOf(null, mock<SentryOptions>(), null)
         assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
@@ -72,7 +72,7 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `when null options is provided, invalid argument is thrown`() {
         val clazz = Class.forName("io.sentry.android.core.DefaultAndroidEventProcessor")
-        val ctor = clazz.getConstructor(Context::class.java, SentryOptions::class.java, IBuildInfoProvider::class.java)
+        val ctor = clazz.getConstructor(Context::class.java, ILogger::class.java, IBuildInfoProvider::class.java)
         val params = arrayOf(mock<Context>(), null, null)
         assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
@@ -80,14 +80,14 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `when null buildInfo is provided, invalid argument is thrown`() {
         val clazz = Class.forName("io.sentry.android.core.DefaultAndroidEventProcessor")
-        val ctor = clazz.getConstructor(Context::class.java, SentryOptions::class.java, IBuildInfoProvider::class.java)
+        val ctor = clazz.getConstructor(Context::class.java, ILogger::class.java, IBuildInfoProvider::class.java)
         val params = arrayOf(null, null, mock<IBuildInfoProvider>())
         assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
 
     @Test
     fun `When hint is not Cached, data should be applied`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo)
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
         var event = SentryEvent().apply {
         }
         // refactor and mock data later on
@@ -95,13 +95,12 @@ class DefaultAndroidEventProcessorTest {
         assertNotNull(event.user)
         assertNotNull(event.contexts.app)
         assertEquals("test", event.debugMeta.images[0].uuid)
-        assertNotNull(event.sdk)
         assertNotNull(event.dist)
     }
 
     @Test
     fun `Current should be true if it comes from main thread`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo)
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
         val sentryThread = SentryThread().apply {
             id = Looper.getMainLooper().thread.id
         }
@@ -115,7 +114,7 @@ class DefaultAndroidEventProcessorTest {
 
     @Test
     fun `Current should be false if it its not the main thread`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo)
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
         val sentryThread = SentryThread().apply {
             id = 10L
         }
@@ -129,7 +128,7 @@ class DefaultAndroidEventProcessorTest {
 
     @Test
     fun `When hint is Cached, data should not be applied`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo)
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
         var event = SentryEvent().apply {
         }
         // refactor and mock data later on
@@ -137,14 +136,13 @@ class DefaultAndroidEventProcessorTest {
         assertNull(event.user)
         assertNull(event.contexts.app)
         assertNull(event.debugMeta)
-        assertNull(event.sdk)
         assertNull(event.release)
         assertNull(event.dist)
     }
 
     @Test
     fun `Executor service should be called on ctor`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo)
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
         val contextData = processor.contextData.get()
         assertNotNull(contextData)
         assertEquals("test", (contextData[PROGUARD_UUID] as Array<*>)[0])
@@ -156,24 +154,15 @@ class DefaultAndroidEventProcessorTest {
 
     @Test
     fun `Processor won't throw exception`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo, mock())
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo, mock())
         processor.process(SentryEvent(), null)
         verify((fixture.options.logger as DiagnosticLogger).logger, never())!!.log(eq(SentryLevel.ERROR), any<String>(), any())
     }
 
     @Test
     fun `Processor won't throw exception when theres a hint`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo, mock())
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo, mock())
         processor.process(SentryEvent(), CachedEvent())
         verify((fixture.options.logger as DiagnosticLogger).logger, never())!!.log(eq(SentryLevel.ERROR), any<String>(), any())
-    }
-
-    @Test
-    fun `Processor sets sdkVersion in the event`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options, fixture.buildInfo, mock())
-        val event = SentryEvent()
-        processor.process(event, null)
-        assertNotNull(event.sdk)
-        assertSame(event.sdk, fixture.options.sdkVersion)
     }
 }

--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -76,6 +76,9 @@ public final class MainEventProcessor implements EventProcessor {
     if (event.getDist() == null) {
       event.setDist(options.getDist());
     }
+    if (event.getSdk() == null) {
+      event.setSdk(options.getSdkVersion());
+    }
 
     if (event.getThreads() == null && options.isAttachThreads()) {
       List<Long> mechanismThreadIds = null;

--- a/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/MainEventProcessorTest.kt
@@ -3,6 +3,7 @@ package io.sentry.core
 import com.nhaarman.mockitokotlin2.mock
 import io.sentry.core.hints.ApplyScopeData
 import io.sentry.core.hints.Cached
+import io.sentry.core.protocol.SdkVersion
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,6 +20,10 @@ class MainEventProcessorTest {
             environment = "environment"
             dist = "dist"
             serverName = "server"
+            sdkVersion = SdkVersion().apply {
+                name = "test"
+                version = "1.2.3"
+            }
         }
         fun getSut(attachThreads: Boolean = true): MainEventProcessor {
             sentryOptions.isAttachThreads = attachThreads
@@ -143,6 +148,16 @@ class MainEventProcessorTest {
         event = sut.process(event, null)
 
         assertNotNull(event.threads)
+    }
+
+    @Test
+    fun `sets sdkVersion in the event`() {
+        val sut = fixture.getSut()
+        val event = SentryEvent()
+        sut.process(event, null)
+        assertNotNull(event.sdk)
+        assertEquals(event.sdk.name, "test")
+        assertEquals(event.sdk.version, "1.2.3")
     }
 
     private fun generateCrashedEvent(crashedThread: Thread = Thread.currentThread()) = SentryEvent().apply {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

SDK version should be set outside of Android specific configuration so that it's taken into account for plain `sentry-java` usage as well as other non-android integrations.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When developing Logback integration (#511) I found out that SDK version is not set on `SentryEvent` even if it's set on `SentryOptions`.

## :green_heart: How did you test it?

"unit tests are green" but I haven't done any real Android device tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Once merged, pull these changes into `feature/sentry-java` branch so that [one test](https://github.com/getsentry/sentry-android/pull/511/files#diff-2a3d6f2986d090a3e4bfa63a870752d3R137) in Logback integration can be un-ignored