### PR TITLE
Warn about Sentry re-initialization.

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/Sentry.java
+++ b/sentry-core/src/main/java/io/sentry/core/Sentry.java
@@ -131,6 +131,15 @@ public final class Sentry {
    */
   private static synchronized void init(
       final @NotNull SentryOptions options, final boolean globalHubMode) {
+    if (isEnabled()) {
+      options
+        .getLogger()
+        .log(
+          SentryLevel.WARNING,
+          "Sentry has been already initialized. Previous configuration will be overwritten."
+        );
+    }
+
     if (!initConfigurations(options)) {
       return;
     }

--- a/sentry-core/src/test/java/io/sentry/core/SentryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryTest.kt
@@ -1,5 +1,8 @@
 package io.sentry.core
 
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.CompletableFuture
@@ -104,6 +107,20 @@ class SentryTest {
         Sentry.configureScope {
             assertEquals(setOf("a"), it.tags.keys)
         }
+    }
+
+    @Test
+    fun `warns about multiple Sentry initializations`() {
+        val logger = mock<ILogger>()
+        Sentry.init {
+            it.dsn = "http://key@localhost/proj"
+        }
+        Sentry.init {
+            it.dsn = "http://key@localhost/proj"
+            it.isDebug = true
+            it.setLogger(logger)
+        }
+        verify(logger).log(eq(SentryLevel.WARNING), eq("Sentry has been already initialized. Previous configuration will be overwritten."))
     }
 
     private fun getTempPath(): String {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

Logs a warning if SDK is initialized more than once - which can happen if user uses two integrations (for example Logback and Spring Boot) but tries to configure both of them. 


## :bulb: Motivation and Context
Problem discussed in https://github.com/getsentry/sentry-android/pull/511#discussion_r472287885


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes