### PR TITLE
Globally disable JdkObsolete check.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.diffplug.spotless.LineEnding
+import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -32,6 +33,7 @@ buildscript {
 }
 
 allprojects {
+    apply<net.ltgt.gradle.errorprone.ErrorPronePlugin>()
     repositories {
         google()
         jcenter()
@@ -52,6 +54,10 @@ allprojects {
         }
         withType<JavaCompile> {
             options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Werror", "-Xlint:-classfile"))
+        }
+
+        withType<JavaCompile>().configureEach {
+            options.errorprone.checks.put("JdkObsolete", net.ltgt.gradle.errorprone.CheckSeverity.OFF)
         }
     }
 }

--- a/sentry-logback/build.gradle.kts
+++ b/sentry-logback/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     `java-library`
     kotlin("jvm")
     jacoco
-    id(Config.QualityPlugins.errorProne)
     id(Config.Deploy.novodaBintray)
     id(Config.QualityPlugins.gradleVersions)
     id(Config.BuildPlugins.buildConfig) version Config.BuildPlugins.buildConfigVersion

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -77,7 +77,6 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
    * @param loggingEvent the logback event
    * @return the sentry event
    */
-  @SuppressWarnings("JdkObsolete")
   final @NotNull SentryEvent createEvent(@NotNull ILoggingEvent loggingEvent) {
     final SentryEvent event = new SentryEvent(DateUtils.getDateTime(new Date(loggingEvent.getTimeStamp())));
     final Message message = new Message();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This is a proposal - if we decide to disable this check, same changes to other modules will have to be applied.

Disables ErrorProne check for [JdkObsolete](https://errorprone.info/bugpattern/JdkObsolete).


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since must stay compatible with older Android APIs we are going to use classes like `java.util.Date` that ErrorProne marks as `JdkObsolete` and logs a warning. Warnings are treated as errors, so our build fails.

We can mark methods that use obsolete classes explicitly with `@SurpressWarnings("JdkObsolete")` - but this isn't clear at first and ideally there should be also a comment explaining why this annotation is there, or we can disable this check globally - as anyway there is a low likelihood that any of the obsolete classes - other than these that we must use - will be used.

Related discussion https://github.com/getsentry/sentry-android/pull/511#discussion_r472289113

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
