### PR TITLE
Add PiiEventProcessor to filter out personal identifiable information

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/PiiEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/PiiEventProcessor.java
@@ -1,0 +1,33 @@
+package io.sentry.core;
+
+import io.sentry.core.protocol.User;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Removes personal identifiable information from {@link SentryEvent} if {@link
+ * SentryOptions#isSendDefaultPii()} is set to false.
+ */
+@ApiStatus.Internal
+final class PiiEventProcessor implements EventProcessor {
+  private final @NotNull SentryOptions options;
+
+  PiiEventProcessor(final @NotNull SentryOptions options) {
+    this.options = options;
+  }
+
+  @Override
+  public SentryEvent process(SentryEvent event, @Nullable Object hint) {
+    if (!options.isSendDefaultPii()) {
+      final User user = event.getUser();
+      if (user != null) {
+        user.setUsername(null);
+        user.setIpAddress(null);
+        user.setEmail(null);
+        event.setUser(user);
+      }
+    }
+    return event;
+  }
+}

--- a/sentry-core/src/main/java/io/sentry/core/PiiEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/PiiEventProcessor.java
@@ -4,6 +4,8 @@ import io.sentry.core.protocol.Request;
 import io.sentry.core.protocol.User;
 import io.sentry.core.util.CollectionUtils;
 import io.sentry.core.util.Objects;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,6 +15,9 @@ import org.jetbrains.annotations.Nullable;
  * SentryOptions#isSendDefaultPii()} is set to false.
  */
 final class PiiEventProcessor implements EventProcessor {
+  private static final List<String> SENSITIVE_HEADERS =
+      Arrays.asList("X-FORWARDED-FOR", "Authorization", "Cookies");
+
   private final @NotNull SentryOptions options;
 
   PiiEventProcessor(final @NotNull SentryOptions options) {
@@ -33,9 +38,9 @@ final class PiiEventProcessor implements EventProcessor {
       if (request != null) {
         final Map<String, String> headers = CollectionUtils.shallowCopy(request.getHeaders());
         if (headers != null) {
-          headers.remove("X-FORWARDED-FOR");
-          headers.remove("Authorization");
-          headers.remove("Cookies");
+          for (String sensitiveHeader : SENSITIVE_HEADERS) {
+            headers.remove(sensitiveHeader);
+          }
           request.setHeaders(headers);
         }
         if (request.getCookies() != null) {

--- a/sentry-core/src/main/java/io/sentry/core/SentryClient.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryClient.java
@@ -92,6 +92,10 @@ public final class SentryClient implements ISentryClient {
       }
     }
 
+    if (event != null) {
+      event = options.getPiiEventProcessor().process(event, hint);
+    }
+
     if (event == null) {
       return SentryId.EMPTY_ID;
     }

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -31,6 +31,8 @@ public class SentryOptions {
    */
   private final @NotNull List<EventProcessor> eventProcessors = new CopyOnWriteArrayList<>();
 
+  private final @NotNull EventProcessor piiEventProcessor;
+
   /**
    * Code that provides middlewares, bindings or hooks into certain frameworks or environments,
    * along with code that inserts those bindings and activates them.
@@ -1007,6 +1009,11 @@ public class SentryOptions {
     this.sendDefaultPii = sendDefaultPii;
   }
 
+  @NotNull
+  public EventProcessor getPiiEventProcessor() {
+    return piiEventProcessor;
+  }
+
   /** The BeforeSend callback */
   public interface BeforeSendCallback {
 
@@ -1047,7 +1054,8 @@ public class SentryOptions {
     integrations.add(new ShutdownHookIntegration());
 
     eventProcessors.add(new MainEventProcessor(this));
-    eventProcessors.add(new PiiEventProcessor(this));
+    // piiEventProcessor is set outside of eventProcessors to make sure that it runs last
+    piiEventProcessor = new PiiEventProcessor(this);
 
     setSentryClientName(BuildConfig.SENTRY_JAVA_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());

--- a/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryOptions.java
@@ -210,6 +210,9 @@ public class SentryOptions {
   /** SdkVersion object that contains the Sentry Client Name and its version */
   private @Nullable SdkVersion sdkVersion;
 
+  /** whether to send personal identifiable information along with events */
+  private boolean sendDefaultPii = false;
+
   /**
    * Adds an event processor
    *
@@ -996,6 +999,14 @@ public class SentryOptions {
     this.sdkVersion = sdkVersion;
   }
 
+  public boolean isSendDefaultPii() {
+    return sendDefaultPii;
+  }
+
+  public void setSendDefaultPii(boolean sendDefaultPii) {
+    this.sendDefaultPii = sendDefaultPii;
+  }
+
   /** The BeforeSend callback */
   public interface BeforeSendCallback {
 
@@ -1036,6 +1047,7 @@ public class SentryOptions {
     integrations.add(new ShutdownHookIntegration());
 
     eventProcessors.add(new MainEventProcessor(this));
+    eventProcessors.add(new PiiEventProcessor(this));
 
     setSentryClientName(BuildConfig.SENTRY_JAVA_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());

--- a/sentry-core/src/test/java/io/sentry/core/PiiEventProcessorTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/PiiEventProcessorTest.kt
@@ -1,0 +1,56 @@
+package io.sentry.core
+
+import io.sentry.core.protocol.User
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class PiiEventProcessorTest {
+
+    private class Fixture {
+        val user = with(User()) {
+            this.id = "some-id"
+            this.username = "john.doe"
+            this.email = "john.doe@example.com"
+            this.ipAddress = "66.249.73.223"
+            this
+        }
+
+        fun getSut(sendPii: Boolean) =
+            PiiEventProcessor(with(SentryOptions()) {
+                this.isSendDefaultPii = sendPii
+                this
+            })
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `when sendDefaultPii is set to false, removes user data from events`() {
+        val eventProcessor = fixture.getSut(sendPii = false)
+        val event = SentryEvent()
+        event.user = fixture.user
+
+        eventProcessor.process(event, null)
+
+        assertNotNull(event.user.id)
+        assertNull(event.user.email)
+        assertNull(event.user.username)
+        assertNull(event.user.ipAddress)
+    }
+
+    @Test
+    fun `when sendDefaultPii is set to true, does not remove user data from events`() {
+        val eventProcessor = fixture.getSut(sendPii = true)
+        val event = SentryEvent()
+        event.user = fixture.user
+
+        eventProcessor.process(event, null)
+
+        assertNotNull(event.user)
+        assertNotNull(event.user.id)
+        assertNotNull(event.user.email)
+        assertNotNull(event.user.username)
+        assertNotNull(event.user.ipAddress)
+    }
+}

--- a/sentry-core/src/test/java/io/sentry/core/PiiEventProcessorTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/PiiEventProcessorTest.kt
@@ -10,27 +10,27 @@ class PiiEventProcessorTest {
 
     private class Fixture {
         val user = with(User()) {
-            this.id = "some-id"
-            this.username = "john.doe"
-            this.email = "john.doe@example.com"
-            this.ipAddress = "66.249.73.223"
+            id = "some-id"
+            username = "john.doe"
+            email = "john.doe@example.com"
+            ipAddress = "66.249.73.223"
             this
         }
 
         val request = with(Request()) {
-            this.headers = mutableMapOf(
+            headers = mutableMapOf(
                 "X-FORWARDED-FOR" to "66.249.73.223",
                 "Authorization" to "token",
                 "Cookies" to "some-cookies",
                 "Safe-Header" to "some-value"
             )
-            this.cookies = "some-cookies"
+            cookies = "some-cookies"
             this
         }
 
         fun getSut(sendPii: Boolean) =
             PiiEventProcessor(with(SentryOptions()) {
-                this.isSendDefaultPii = sendPii
+                isSendDefaultPii = sendPii
                 this
             })
     }

--- a/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryClientTest.kt
@@ -441,6 +441,21 @@ class SentryClientTest {
     }
 
     @Test
+    fun `pii event processor is the last event processor applied`() {
+        val processor = EventProcessor { event, hint ->
+            event.user = User()
+            event.user.email = "john.doe@example.com"
+            event
+        }
+        fixture.sentryOptions.addEventProcessor(processor)
+
+        val event = SentryEvent()
+
+        fixture.getSut().captureEvent(event)
+        assertNull(event.user.email)
+    }
+
+    @Test
     fun `when captureSession and no release is set, do nothing`() {
         fixture.getSut().captureSession(createSession(""))
         verify(fixture.connection, never()).send(any<SentryEnvelope>())


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Adds an option for users to decide if they want to send personal identifiable information (email, username, ip address) along with the events.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Discussion initially started when working on Spring Boot integration - we want to give users option to decide if detailed user information is sent or not - similar to how it's done in Python integration: https://docs.sentry.io/error-reporting/configuration/?platform=python

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes

Breaking change: sending PII is turn off by default.