### PR TITLE
Attach breadcrumbs to events triggered in Logback integration.

### DIFF
--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import io.sentry.core.Breadcrumb;
 import io.sentry.core.DateUtils;
 import io.sentry.core.Sentry;
 import io.sentry.core.SentryEvent;
@@ -29,6 +30,8 @@ import org.jetbrains.annotations.Nullable;
 public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @Nullable SentryOptions options;
   private @Nullable ITransport transport;
+  private @Nullable Level minimumBreadcrumbLevel;
+  private @Nullable Level minimumEventLevel;
 
   @Override
   public void start() {
@@ -43,7 +46,13 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
 
   @Override
   protected void append(@NotNull ILoggingEvent eventObject) {
-    Sentry.captureEvent(createEvent(eventObject));
+    if (minimumEventLevel == null || eventObject.getLevel().isGreaterOrEqual(minimumEventLevel)) {
+      Sentry.captureEvent(createEvent(eventObject));
+    }
+    if (minimumBreadcrumbLevel == null
+        || eventObject.getLevel().isGreaterOrEqual(minimumBreadcrumbLevel)) {
+      Sentry.addBreadcrumb(createBreadcrumb(eventObject));
+    }
   }
 
   /**
@@ -94,6 +103,20 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
   }
 
   /**
+   * Creates {@link Breadcrumb} from Logback's {@link ILoggingEvent}.
+   *
+   * @param loggingEvent the logback event
+   * @return the sentry breadcrumb
+   */
+  private @NotNull Breadcrumb createBreadcrumb(final @NotNull ILoggingEvent loggingEvent) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setLevel(formatLevel(loggingEvent.getLevel()));
+    breadcrumb.setCategory(loggingEvent.getLoggerName());
+    breadcrumb.setMessage(loggingEvent.getFormattedMessage());
+    return breadcrumb;
+  }
+
+  /**
    * Transforms a {@link Level} into an {@link SentryLevel}.
    *
    * @param level original level as defined in log4j.
@@ -126,8 +149,16 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
     return sdkVersion;
   }
 
-  public void setOptions(SentryOptions options) {
+  public void setOptions(final @Nullable SentryOptions options) {
     this.options = options;
+  }
+
+  public void setMinimumBreadcrumbLevel(final @Nullable Level minimumBreadcrumbLevel) {
+    this.minimumBreadcrumbLevel = minimumBreadcrumbLevel;
+  }
+
+  public void setMinimumEventLevel(final @Nullable Level minimumEventLevel) {
+    this.minimumEventLevel = minimumEventLevel;
   }
 
   @ApiStatus.Internal

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -30,8 +30,8 @@ import org.jetbrains.annotations.Nullable;
 public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @Nullable SentryOptions options;
   private @Nullable ITransport transport;
-  private @Nullable Level minimumBreadcrumbLevel;
-  private @Nullable Level minimumEventLevel;
+  private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
+  private @NotNull Level minimumEventLevel = Level.ERROR;
 
   @Override
   public void start() {
@@ -46,11 +46,10 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
 
   @Override
   protected void append(@NotNull ILoggingEvent eventObject) {
-    if (minimumEventLevel == null || eventObject.getLevel().isGreaterOrEqual(minimumEventLevel)) {
+    if (eventObject.getLevel().isGreaterOrEqual(minimumEventLevel)) {
       Sentry.captureEvent(createEvent(eventObject));
     }
-    if (minimumBreadcrumbLevel == null
-        || eventObject.getLevel().isGreaterOrEqual(minimumBreadcrumbLevel)) {
+    if (eventObject.getLevel().isGreaterOrEqual(minimumBreadcrumbLevel)) {
       Sentry.addBreadcrumb(createBreadcrumb(eventObject));
     }
   }
@@ -154,11 +153,15 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
   }
 
   public void setMinimumBreadcrumbLevel(final @Nullable Level minimumBreadcrumbLevel) {
-    this.minimumBreadcrumbLevel = minimumBreadcrumbLevel;
+    if (minimumBreadcrumbLevel != null) {
+      this.minimumBreadcrumbLevel = minimumBreadcrumbLevel;
+    }
   }
 
   public void setMinimumEventLevel(final @Nullable Level minimumEventLevel) {
-    this.minimumEventLevel = minimumEventLevel;
+    if (minimumEventLevel != null) {
+      this.minimumEventLevel = minimumEventLevel;
+    }
   }
 
   @ApiStatus.Internal

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.logback
 
 import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Level.WARN
 import ch.qos.logback.classic.LoggerContext
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
@@ -28,31 +29,30 @@ import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 
 class SentryAppenderTest {
-    private class Fixture {
+    private class Fixture(minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null) {
         val transport = mock<ITransport>()
         val logger: Logger = LoggerFactory.getLogger(SentryAppenderTest::class.java)
         val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
 
         init {
             whenever(transport.send(any<SentryEvent>())).thenReturn(TransportResult.success())
-
             val appender = SentryAppender()
             val options = SentryOptions()
             options.dsn = "http://key@localhost/proj"
             appender.setOptions(options)
+            appender.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
+            appender.setMinimumEventLevel(minimumEventLevel)
             appender.context = loggerContext
             appender.setTransport(transport)
-
             val rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
             rootLogger.level = Level.TRACE
             rootLogger.addAppender(appender)
-
             appender.start()
             loggerContext.start()
         }
     }
 
-    private val fixture = Fixture()
+    private lateinit var fixture: Fixture
 
     @AfterTest
     fun `stop logback`() {
@@ -66,6 +66,7 @@ class SentryAppenderTest {
 
     @Test
     fun `converts message`() {
+        fixture = Fixture()
         fixture.logger.debug("testing message conversion {}, {}", 1, 2)
 
         await.untilAsserted {
@@ -80,6 +81,7 @@ class SentryAppenderTest {
 
     @Test
     fun `event date is in UTC`() {
+        fixture = Fixture()
         val utcTime = LocalDateTime.now(ZoneId.of("UTC"))
 
         fixture.logger.debug("testing event date")
@@ -98,6 +100,7 @@ class SentryAppenderTest {
 
     @Test
     fun `converts trace log level to Sentry level`() {
+        fixture = Fixture()
         fixture.logger.trace("testing trace level")
 
         await.untilAsserted {
@@ -109,6 +112,7 @@ class SentryAppenderTest {
 
     @Test
     fun `converts debug log level to Sentry level`() {
+        fixture = Fixture()
         fixture.logger.debug("testing debug level")
 
         await.untilAsserted {
@@ -120,6 +124,7 @@ class SentryAppenderTest {
 
     @Test
     fun `converts info log level to Sentry level`() {
+        fixture = Fixture()
         fixture.logger.info("testing info level")
 
         await.untilAsserted {
@@ -131,6 +136,7 @@ class SentryAppenderTest {
 
     @Test
     fun `converts warn log level to Sentry level`() {
+        fixture = Fixture()
         fixture.logger.warn("testing warn level")
 
         await.untilAsserted {
@@ -142,6 +148,7 @@ class SentryAppenderTest {
 
     @Test
     fun `converts error log level to Sentry level`() {
+        fixture = Fixture()
         fixture.logger.error("testing error level")
 
         await.untilAsserted {
@@ -153,6 +160,7 @@ class SentryAppenderTest {
 
     @Test
     fun `attaches thread information`() {
+        fixture = Fixture()
         fixture.logger.warn("testing thread information")
 
         await.untilAsserted {
@@ -164,6 +172,7 @@ class SentryAppenderTest {
 
     @Test
     fun `sets tags from MDC`() {
+        fixture = Fixture()
         MDC.put("key", "value")
         fixture.logger.warn("testing MDC tags")
 
@@ -176,6 +185,7 @@ class SentryAppenderTest {
 
     @Test
     fun `does not create MDC context when no MDC tags are set`() {
+        fixture = Fixture()
         fixture.logger.warn("testing without MDC tags")
 
         await.untilAsserted {
@@ -187,6 +197,7 @@ class SentryAppenderTest {
 
     @Test
     fun `attaches throwable`() {
+        fixture = Fixture()
         val throwable = RuntimeException("something went wrong")
         fixture.logger.warn("testing throwable", throwable)
 
@@ -199,6 +210,7 @@ class SentryAppenderTest {
 
     @Test
     fun `sets SDK version`() {
+        fixture = Fixture()
         fixture.logger.info("testing sdk version")
 
         await.untilAsserted {
@@ -210,6 +222,31 @@ class SentryAppenderTest {
                     "maven:sentry-logback" == pkg.name &&
                         BuildConfig.VERSION_NAME == pkg.version
                 })
+            })
+        }
+    }
+
+    @Test
+    fun `attaches breadcrumbs`() {
+        fixture = Fixture(minimumBreadcrumbLevel = Level.DEBUG, minimumEventLevel = WARN)
+        val utcTime = LocalDateTime.now(ZoneId.of("UTC"))
+
+        fixture.logger.debug("this should be a breadcrumb #1")
+        fixture.logger.info("this should be a breadcrumb #2")
+        fixture.logger.warn("testing message with breadcrumbs")
+
+        await.untilAsserted {
+            verify(fixture.transport).send(check { it: SentryEvent ->
+                assertEquals(2, it.breadcrumbs.size)
+                val breadcrumb = it.breadcrumbs[0]
+                val breadcrumbTime = Instant.ofEpochMilli(it.timestamp.time)
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime()
+                assertTrue { breadcrumbTime.plusSeconds(1).isAfter(utcTime) }
+                assertTrue { breadcrumbTime.minusSeconds(1).isBefore(utcTime) }
+                assertEquals("this should be a breadcrumb #1", breadcrumb.message)
+                assertEquals("io.sentry.logback.SentryAppenderTest", breadcrumb.category)
+                assertEquals(SentryLevel.DEBUG, breadcrumb.level)
             })
         }
     }

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -11,7 +11,10 @@
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
       <dsn>https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954</dsn>
     </options>
+    <!-- Demonstrates how to modify the minimum values -->
+    <!-- Default for Events is ERROR -->
     <minimumEventLevel>WARN</minimumEventLevel>
+    <!-- Default for Events is INFO -->
     <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
   </appender>
 

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -11,13 +11,11 @@
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
       <dsn>https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954</dsn>
     </options>
-
-    <!-- Optionally you can filter what statements are sent to Sentry independently from loggers configuration -->
-<!--    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">-->
-<!--      <level>WARN</level>-->
-<!--    </filter>-->
+    <minimumEventLevel>WARN</minimumEventLevel>
+    <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
   </appender>
 
+  <!-- it's important to set logger level to equal or lower than minimumBreadcrumbLevel and minimumEventLevel -->
   <root level="debug">
     <appender-ref ref="sentry"/>
   </root>

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->
     <minimumEventLevel>WARN</minimumEventLevel>
-    <!-- Default for Events is INFO -->
+    <!-- Default for Breadcrumbs is INFO -->
     <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
   </appender>
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Logback integration gets now an option to set `minimumEventLevel` and `minimumBreadcrumbLevel`. Breadcrumbs are attached to current scope and sent along with following `SentryEvent`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Requested by @bruno-garcia.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
