### PR TITLE
Fix resolving isAttachStacktrace flag.

### DIFF
--- a/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
+++ b/sentry-core/src/main/java/io/sentry/core/MainEventProcessor.java
@@ -23,7 +23,7 @@ public final class MainEventProcessor implements EventProcessor {
 
     sentryExceptionFactory = new SentryExceptionFactory(sentryStackTraceFactory);
     sentryThreadFactory =
-        new SentryThreadFactory(sentryStackTraceFactory, this.options.isAttachStacktrace());
+        new SentryThreadFactory(sentryStackTraceFactory, this.options);
   }
 
   MainEventProcessor(

--- a/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
+++ b/sentry-core/src/main/java/io/sentry/core/SentryThreadFactory.java
@@ -18,31 +18,21 @@ final class SentryThreadFactory {
   private final @NotNull SentryStackTraceFactory sentryStackTraceFactory;
 
   /**
-   * When enabled, stack traces are automatically attached to all threads logged. Stack traces are
-   * always attached to exceptions but when this is set stack traces are also sent with threads
+   * the SentryOptions.
    */
-  private final boolean attachStacktrace;
+  private final @NotNull SentryOptions options;
 
   /**
    * ctor SentryThreadFactory that takes a SentryStackTraceFactory
    *
    * @param sentryStackTraceFactory the SentryStackTraceFactory
-   * @param attachStacktrace the attachStacktrace
+   * @param options the SentryOptions
    */
   public SentryThreadFactory(
-      final @NotNull SentryStackTraceFactory sentryStackTraceFactory, boolean attachStacktrace) {
+      final @NotNull SentryStackTraceFactory sentryStackTraceFactory, final @NotNull SentryOptions options) {
     this.sentryStackTraceFactory =
         Objects.requireNonNull(sentryStackTraceFactory, "The SentryStackTraceFactory is required.");
-    this.attachStacktrace = attachStacktrace;
-  }
-
-  /**
-   * ctor SentryThreadFactory that takes a SentryStackTraceFactory
-   *
-   * @param sentryStackTraceFactory the SentryStackTraceFactory
-   */
-  public SentryThreadFactory(final @NotNull SentryStackTraceFactory sentryStackTraceFactory) {
-    this(sentryStackTraceFactory, false);
+    this.options = Objects.requireNonNull(options, "The SentryOptions is required");
   }
 
   /**
@@ -120,7 +110,7 @@ final class SentryThreadFactory {
     final List<SentryStackFrame> frames =
         sentryStackTraceFactory.getStackFrames(stackFramesElements);
 
-    if (attachStacktrace && frames != null && frames.size() > 0) {
+    if (options.isAttachStacktrace() && frames != null && frames.size() > 0) {
       sentryThread.setStacktrace(new SentryStackTrace(frames));
     }
 

--- a/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
+++ b/sentry-core/src/test/java/io/sentry/core/SentryThreadFactoryTest.kt
@@ -11,7 +11,10 @@ import kotlin.test.assertTrue
 class SentryThreadFactoryTest {
 
     class Fixture {
-        internal fun getSut(attachStacktrace: Boolean = true) = SentryThreadFactory(SentryStackTraceFactory(listOf("io.sentry"), listOf()), attachStacktrace)
+        internal fun getSut(attachStacktrace: Boolean = true) = SentryThreadFactory(SentryStackTraceFactory(listOf("io.sentry"), listOf()), with(SentryOptions()) {
+            isAttachStacktrace = attachStacktrace
+            this
+        })
     }
 
     private val fixture = Fixture()


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

`isAttachStacktrace` was passed down in `SentryOptions` constructor before this field was initialized with setters.

This PR changes it in a way that instead of raw value, instances of `SentryOptions` is passed down which also enables potential reconfiguring of this flag during runtime.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was a bug we found out while working on Spring integration.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
